### PR TITLE
Release Action now creates versioned release + tags

### DIFF
--- a/.github/workflows/mocale-release.yml
+++ b/.github/workflows/mocale-release.yml
@@ -31,11 +31,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - uses: actions/checkout@v3
+
     - uses: actions/download-artifact@v2
       with:
         name: ${{ inputs.artifact-name }}
         path: Artifacts/
-        workflow: Mocale CI
 
     - name: Process NuGet Version
       shell: pwsh

--- a/.github/workflows/mocale-release.yml
+++ b/.github/workflows/mocale-release.yml
@@ -33,10 +33,15 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: actions/download-artifact@v2
+    - name: Download artifacts
+      id: download-artifact
+      uses: dawidd6/action-download-artifact@v2
       with:
         name: ${{ inputs.artifact-name }}
+        repo: Axemasta/Mocale
+        workflow: mocale-ci.yml
         path: Artifacts/
+        search_artifacts: true
 
     - name: Process NuGet Version
       shell: pwsh

--- a/.github/workflows/mocale-release.yml
+++ b/.github/workflows/mocale-release.yml
@@ -26,11 +26,6 @@ on:
         description: Whether to fail the build if there are errors in the artifact.
         default: true
 
-
-env:
-  IS_PRERELEASE: true
-  VERSION_NAME: "0.0.1"
-
 jobs:
   github-release:
     runs-on: ubuntu-latest
@@ -77,12 +72,13 @@ jobs:
         }
 
         if ($IsPreRelease) {
-            echo "IS_PRERELEASE=true" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            echo "IS_PRERELEASE=true" >> "$GITHUB_ENV"
         } else {
-          echo "IS_PRERELEASE=false" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "IS_PRERELEASE=false" >> "$GITHUB_ENV"
+
         }
 
-        echo "VERSION_NAME=$ArtifactName" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "VERSION_NAME=$ArtifactName" >> "$GITHUB_ENV"
 
         Write-Host "Env Variables After:"
         echo $Env:IS_PRERELEASE

--- a/.github/workflows/mocale-release.yml
+++ b/.github/workflows/mocale-release.yml
@@ -60,19 +60,22 @@ jobs:
             $IsPreRelease = $true
         }
 
+        Write-Host "Artifact name: $($ArtifactName)"
+        Write-Host "Is pre release: $($IsPreRelease)"
+
         if ($IsPreRelease) {
-            Write-Host "::set-output name=is-preview::true\n"
+            echo "is-preview=true" >> $IS_PRERELEASE
         } else {
-            Write-Host "::set-output name=is-preview::false\n"
+          echo "is-preview=false" >> $IS_PRERELEASE
         }
 
-        Write-Host "::set-output name=version-name::v$ArtifactName\n"
+        echo "version-name=$ArtifactName" >> $VERSION_NAME
 
     - name: Bump version and push tag
       id: tag_version
       uses: mathieudutour/github-tag-action@v6.1
       with:
-        tag: ${{ steps.process-version.outputs.version-name }}
+        tag: ${{ steps.process-version.outputs.VERSION_NAME }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: ncipollo/release-action@main
@@ -83,6 +86,7 @@ jobs:
         draft: true
         generateReleaseNotes: false
         name: ${{ inputs.release-title }}
-        prerelease: ${{ steps.process-version.outputs.is-preview }}
+        tag: ${{ steps.process-version.outputs.VERSION_NAME }}
+        prerelease: ${{ steps.process-version.outputs.IS_PRERELEASE }}
 
     # Deploy To NuGet

--- a/.github/workflows/mocale-release.yml
+++ b/.github/workflows/mocale-release.yml
@@ -74,12 +74,13 @@ jobs:
         }
 
         if ($IsPreRelease) {
-            echo "IS_PRERELEASE=true" >> "$GITHUB_ENV"
+          echo "IS_PRERELEASE=true" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         } else {
-          echo "IS_PRERELEASE=false" >> "$GITHUB_ENV"
+          echo "IS_PRERELEASE=false" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         }
 
-        echo "VERSION_NAME=$ArtifactName" >> "$GITHUB_ENV"
+        echo "action_state=$ArtifactName" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "VERSION_NAME=$ArtifactName" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
         Write-Host "ArtifactName = $ArtifactName"
         Write-Host "Is PreRelease = $IsPreRelease"
@@ -91,8 +92,10 @@ jobs:
     - name: Use the value
       id: step_two
       run: |
+        echo "${{ env.action_state }}"
+        echo "${{ env.VERSION_NAME }}"
+        echo "${{ env.IS_PRERELEASE }}"
 
-        echo "${{ env.VERSION_NAME }}" # This will output 'yellow'
     # - name: Bump version and push tag
     #   id: tag_version
     #   uses: mathieudutour/github-tag-action@v6.1

--- a/.github/workflows/mocale-release.yml
+++ b/.github/workflows/mocale-release.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         name: ${{ inputs.artifact-name }}
         path: Artifacts/
-        workflow: mocale-ci.yml
+        workflow: Mocale CI
 
     - name: Process NuGet Version
       shell: pwsh

--- a/.github/workflows/mocale-release.yml
+++ b/.github/workflows/mocale-release.yml
@@ -68,34 +68,42 @@ jobs:
 
         $IsPreRelease = $false
 
+        Write-Host "Env Variables Before:"
+        echo $Env:IS_PRERELEASE
+        echo $Env:VERSION_NAME
+
         if ($ArtifactName.EndsWith("-pre")) {
             $IsPreRelease = $true
         }
 
         if ($IsPreRelease) {
-            echo "IS_PRERELEASE=true >> $GITHUB_ENV"
+            echo "IS_PRERELEASE=true" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         } else {
-          echo "IS_PRERELEASE=false >> $GITHUB_ENV"
+          echo "IS_PRERELEASE=false" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         }
 
-        echo "VERSION_NAME=$($ArtifactName) >> $GITHUB_ENV"
+        echo "VERSION_NAME=$ArtifactName" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-    - name: Bump version and push tag
-      id: tag_version
-      uses: mathieudutour/github-tag-action@v6.1
-      with:
-        custom_tag: ${{ env.VERSION_NAME }}
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        Write-Host "Env Variables After:"
+        echo $Env:IS_PRERELEASE
+        echo $Env:VERSION_NAME
 
-    - uses: ncipollo/release-action@main
-      name: Create Release
-      with:
-        artifacts: ${{ inputs.artifacts }}
-        artifactErrorsFailBuild: ${{ inputs.artifactErrorsFailBuild }}
-        draft: true
-        generateReleaseNotes: false
-        name: ${{ inputs.release-title }}
-        tag: ${{ env.VERSION_NAME }}
-        prerelease: ${{ env.IS_PRERELEASE }}
+    # - name: Bump version and push tag
+    #   id: tag_version
+    #   uses: mathieudutour/github-tag-action@v6.1
+    #   with:
+    #     custom_tag: ${{ env.VERSION_NAME }}
+    #     github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    # - uses: ncipollo/release-action@main
+    #   name: Create Release
+    #   with:
+    #     artifacts: ${{ inputs.artifacts }}
+    #     artifactErrorsFailBuild: ${{ inputs.artifactErrorsFailBuild }}
+    #     draft: true
+    #     generateReleaseNotes: false
+    #     name: ${{ inputs.release-title }}
+    #     tag: ${{ env.VERSION_NAME }}
+    #     prerelease: ${{ env.IS_PRERELEASE }}
 
     # Deploy To NuGet

--- a/.github/workflows/mocale-release.yml
+++ b/.github/workflows/mocale-release.yml
@@ -91,7 +91,7 @@ jobs:
         artifacts: ${{ inputs.artifacts }}
         artifactErrorsFailBuild: ${{ inputs.artifactErrorsFailBuild }}
         draft: true
-        generateReleaseNotes: false
+        generateReleaseNotes: true
         name: ${{ env.RELEASE_TITLE }}
         tag: ${{ env.VERSION_NAME }}
         prerelease: ${{ env.IS_PRERELEASE }}

--- a/.github/workflows/mocale-release.yml
+++ b/.github/workflows/mocale-release.yml
@@ -65,10 +65,6 @@ jobs:
 
         $IsPreRelease = $false
 
-        Write-Host "Env Variables Before:"
-        echo $Env:IS_PRERELEASE
-        echo $Env:VERSION_NAME
-
         if ($ArtifactName.EndsWith("-pre")) {
             $IsPreRelease = $true
         }
@@ -85,23 +81,12 @@ jobs:
         Write-Host "ArtifactName = $ArtifactName"
         Write-Host "Is PreRelease = $IsPreRelease"
 
-        Write-Host "Env Variables After:"
-        echo $Env:IS_PRERELEASE
-        echo $Env:VERSION_NAME
-
-    - name: Use the value
-      id: step_two
-      run: |
-        echo "${{ env.action_state }}"
-        echo "${{ env.VERSION_NAME }}"
-        echo "${{ env.IS_PRERELEASE }}"
-
-    # - name: Bump version and push tag
-    #   id: tag_version
-    #   uses: mathieudutour/github-tag-action@v6.1
-    #   with:
-    #     custom_tag: ${{ env.VERSION_NAME }}
-    #     github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Bump version and push tag
+      id: tag_version
+      uses: mathieudutour/github-tag-action@v6.1
+      with:
+        custom_tag: ${{ env.VERSION_NAME }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
 
     # - uses: ncipollo/release-action@main
     #   name: Create Release

--- a/.github/workflows/mocale-release.yml
+++ b/.github/workflows/mocale-release.yml
@@ -27,6 +27,10 @@ on:
         default: true
 
 
+env:
+  IS_PRERELEASE: true
+  VERSION_NAME: "0.0.1"
+
 jobs:
   github-release:
     runs-on: ubuntu-latest
@@ -68,22 +72,19 @@ jobs:
             $IsPreRelease = $true
         }
 
-        Write-Host "Artifact name: $($ArtifactName)"
-        Write-Host "Is pre release: $($IsPreRelease)"
-
         if ($IsPreRelease) {
-            echo "IS_PRERELEASE=true"
+            echo "IS_PRERELEASE=true >> $GITHUB_ENV"
         } else {
-          echo "IS_PRERELEASE=false"
+          echo "IS_PRERELEASE=false >> $GITHUB_ENV"
         }
 
-        echo "VERSION_NAME=$($ArtifactName)"
+        echo "VERSION_NAME=$($ArtifactName) >> $GITHUB_ENV"
 
     - name: Bump version and push tag
       id: tag_version
       uses: mathieudutour/github-tag-action@v6.1
       with:
-        custom_tag: ${{ steps.process-version.outputs.VERSION_NAME }}
+        custom_tag: ${{ env.VERSION_NAME }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: ncipollo/release-action@main
@@ -94,7 +95,7 @@ jobs:
         draft: true
         generateReleaseNotes: false
         name: ${{ inputs.release-title }}
-        tag: ${{ steps.process-version.outputs.VERSION_NAME }}
-        prerelease: ${{ steps.process-version.outputs.IS_PRERELEASE }}
+        tag: ${{ env.VERSION_NAME }}
+        prerelease: ${{ env.IS_PRERELEASE }}
 
     # Deploy To NuGet

--- a/.github/workflows/mocale-release.yml
+++ b/.github/workflows/mocale-release.yml
@@ -48,7 +48,7 @@ jobs:
       working-directory: Artifacts/
       id: process-version
       run: |
-        $ Artifact = Get-ChildItem -Recurse | Where-Object { $_.Name.EndsWith('.nupkg') -and $_.Name.BeginsWith('Mocale.') }
+        $Artifact = Get-ChildItem -Recurse | Where-Object { $_.Name.EndsWith('.nupkg') -and $_.Name.StartsWith('Mocale.') }
 
         $ArtifactName = $Artifact.Name
         $ArtifactName = $ArtifactName.Replace("Mocale.", "")

--- a/.github/workflows/mocale-release.yml
+++ b/.github/workflows/mocale-release.yml
@@ -29,7 +29,9 @@ on:
 jobs:
   github-release:
     runs-on: ubuntu-latest
-
+    env:
+      IS_PRERELEASE: true
+      VERSION_NAME: 0.0.1
     steps:
     - uses: actions/checkout@v3
 
@@ -75,15 +77,22 @@ jobs:
             echo "IS_PRERELEASE=true" >> "$GITHUB_ENV"
         } else {
           echo "IS_PRERELEASE=false" >> "$GITHUB_ENV"
-
         }
 
         echo "VERSION_NAME=$ArtifactName" >> "$GITHUB_ENV"
+
+        Write-Host "ArtifactName = $ArtifactName"
+        Write-Host "Is PreRelease = $IsPreRelease"
 
         Write-Host "Env Variables After:"
         echo $Env:IS_PRERELEASE
         echo $Env:VERSION_NAME
 
+    - name: Use the value
+      id: step_two
+      run: |
+
+        echo "${{ env.VERSION_NAME }}" # This will output 'yellow'
     # - name: Bump version and push tag
     #   id: tag_version
     #   uses: mathieudutour/github-tag-action@v6.1

--- a/.github/workflows/mocale-release.yml
+++ b/.github/workflows/mocale-release.yml
@@ -10,12 +10,7 @@ on:
       artifacts:
         type: string
         description: The path to the artifacts.
-        default: "Artifacts/*.nupkg"
-      release-title:
-        type: string
-        description: The title of the release.
-        default: "Release"
-        required: true
+        default: "Artifacts/**/*.nupkg"
       release-notes:
         type: string
         description: The notes for the release.
@@ -31,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IS_PRERELEASE: true
+      RELEASE_TITLE: v0.0.1
       VERSION_NAME: 0.0.1
     steps:
     - uses: actions/checkout@v3
@@ -77,6 +73,7 @@ jobs:
 
         echo "action_state=$ArtifactName" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         echo "VERSION_NAME=$ArtifactName" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "RELEASE_TITLE=v$ArtifactName" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
         Write-Host "ArtifactName = $ArtifactName"
         Write-Host "Is PreRelease = $IsPreRelease"
@@ -95,8 +92,9 @@ jobs:
         artifactErrorsFailBuild: ${{ inputs.artifactErrorsFailBuild }}
         draft: true
         generateReleaseNotes: false
-        name: ${{ inputs.release-title }}
+        name: ${{ env.RELEASE_TITLE }}
         tag: ${{ env.VERSION_NAME }}
         prerelease: ${{ env.IS_PRERELEASE }}
+        body: ${{ inputs.release-notes }}
 
     # Deploy To NuGet

--- a/.github/workflows/mocale-release.yml
+++ b/.github/workflows/mocale-release.yml
@@ -88,15 +88,15 @@ jobs:
         custom_tag: ${{ env.VERSION_NAME }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
-    # - uses: ncipollo/release-action@main
-    #   name: Create Release
-    #   with:
-    #     artifacts: ${{ inputs.artifacts }}
-    #     artifactErrorsFailBuild: ${{ inputs.artifactErrorsFailBuild }}
-    #     draft: true
-    #     generateReleaseNotes: false
-    #     name: ${{ inputs.release-title }}
-    #     tag: ${{ env.VERSION_NAME }}
-    #     prerelease: ${{ env.IS_PRERELEASE }}
+    - uses: ncipollo/release-action@main
+      name: Create Release
+      with:
+        artifacts: ${{ inputs.artifacts }}
+        artifactErrorsFailBuild: ${{ inputs.artifactErrorsFailBuild }}
+        draft: true
+        generateReleaseNotes: false
+        name: ${{ inputs.release-title }}
+        tag: ${{ env.VERSION_NAME }}
+        prerelease: ${{ env.IS_PRERELEASE }}
 
     # Deploy To NuGet

--- a/.github/workflows/mocale-release.yml
+++ b/.github/workflows/mocale-release.yml
@@ -49,10 +49,17 @@ jobs:
       id: process-version
       run: |
         $Artifact = Get-ChildItem -Recurse | Where-Object { $_.Name.EndsWith('.nupkg') -and $_.Name.StartsWith('Mocale.') } | Select-Object -First 1
-
         $ArtifactName = $Artifact.Name
-        $ArtifactName = $ArtifactName.Replace("Mocale.", "")
-        $ArtifactName = $ArtifactName.Replace(".nupkg", "")
+        $Pattern = '\b\d+\.\d+\.\d+(-\w+)?\b'
+
+        $Match = [regex]::Match($ArtifactName, $Pattern)
+
+        if (!$Match.Success) {
+            Write-Host "Unable to parse version number for artifact: $($ArtifactName)"
+            exit
+        }
+
+        $ArtifactName = $Match.Value
 
         $IsPreRelease = $false
 

--- a/.github/workflows/mocale-release.yml
+++ b/.github/workflows/mocale-release.yml
@@ -35,6 +35,7 @@ jobs:
       with:
         name: ${{ inputs.artifact-name }}
         path: Artifacts/
+        workflow: mocale-ci.yml
 
     - name: Process NuGet Version
       shell: pwsh

--- a/.github/workflows/mocale-release.yml
+++ b/.github/workflows/mocale-release.yml
@@ -48,7 +48,7 @@ jobs:
       working-directory: Artifacts/
       id: process-version
       run: |
-        $Artifact = Get-ChildItem -Recurse | Where-Object { $_.Name.EndsWith('.nupkg') -and $_.Name.StartsWith('Mocale.') }
+        $Artifact = Get-ChildItem -Recurse | Where-Object { $_.Name.EndsWith('.nupkg') -and $_.Name.StartsWith('Mocale.') } | Select-Object -First 1
 
         $ArtifactName = $Artifact.Name
         $ArtifactName = $ArtifactName.Replace("Mocale.", "")

--- a/.github/workflows/mocale-release.yml
+++ b/.github/workflows/mocale-release.yml
@@ -26,6 +26,7 @@ on:
         description: Whether to fail the build if there are errors in the artifact.
         default: true
 
+
 jobs:
   github-release:
     runs-on: ubuntu-latest
@@ -71,18 +72,18 @@ jobs:
         Write-Host "Is pre release: $($IsPreRelease)"
 
         if ($IsPreRelease) {
-            echo "is-preview=true" >> $IS_PRERELEASE
+            echo "IS_PRERELEASE=true"
         } else {
-          echo "is-preview=false" >> $IS_PRERELEASE
+          echo "IS_PRERELEASE=false"
         }
 
-        echo "version-name=$ArtifactName" >> $VERSION_NAME
+        echo "VERSION_NAME=$($ArtifactName)"
 
     - name: Bump version and push tag
       id: tag_version
       uses: mathieudutour/github-tag-action@v6.1
       with:
-        tag: ${{ steps.process-version.outputs.VERSION_NAME }}
+        custom_tag: ${{ steps.process-version.outputs.VERSION_NAME }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: ncipollo/release-action@main


### PR DESCRIPTION
This was a bit of a fight with github actions and setting environment variables but now the release pipeline:

- Downloads build artifacts
- Determines release version and type
- Sets a git tag
- Creates a github release

This is triggered manually and notes have to be manually added. This seems like a nice compromise between automating the workflow and not having to do too much