### PR TITLE
Add Links To Shields

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ The following packages are available via NuGet
 
 | Package                                                      | NuGet                                                        |
 | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| [Mocale](https://www.nuget.org/packages/Mocale/)             | ![Mocale NuGet Shield](https://img.shields.io/nuget/v/mocale) |
-| [Mocale.Cache.SQLite](https://www.nuget.org/packages/Mocale.Cache.SQLite/) | ![Mocale.Cache.SQLite NuGet Shield](https://img.shields.io/nuget/v/mocale.cache.sqlite) |
-| [Mocale.Providers.Azure.Blob](https://www.nuget.org/packages/Mocale.Providers.Azure.Blob/) | ![Mocale.Providers.Azure.Blob NuGet Shield](https://img.shields.io/nuget/v/mocale.providers.azure.blob) |
-| [Mocale.SourceGenerators](https://www.nuget.org/packages/Mocale.SourceGenerators/) | ![Mocale.SourceGenerators NuGet Shield](https://img.shields.io/nuget/v/mocale.sourcegenerators) |
+| [Mocale](https://www.nuget.org/packages/Mocale/)             | [![Mocale NuGet Shield](https://img.shields.io/nuget/v/mocale)](https://www.nuget.org/packages/Mocale/) |
+| [Mocale.Cache.SQLite](https://www.nuget.org/packages/Mocale.Cache.SQLite/) | [![Mocale.Cache.SQLite NuGet Shield](https://img.shields.io/nuget/v/mocale.cache.sqlite)](https://www.nuget.org/packages/Mocale.Cache.SQLite/) |
+| [Mocale.Providers.Azure.Blob](https://www.nuget.org/packages/Mocale.Providers.Azure.Blob/) | [![Mocale.Providers.Azure.Blob NuGet Shield](https://img.shields.io/nuget/v/mocale.providers.azure.blob)](https://www.nuget.org/packages/Mocale.Providers.Azure.Blob/) |
+| [Mocale.SourceGenerators](https://www.nuget.org/packages/Mocale.SourceGenerators/) | [![Mocale.SourceGenerators NuGet Shield](https://img.shields.io/nuget/v/mocale.sourcegenerators)](https://www.nuget.org/packages/Mocale.SourceGenerators/) |
 
 
 


### PR DESCRIPTION
The nuget shield badges didnt actually link out to the library, instead it opened the image in a new tab.

This PR adds markdown hyperlinks to the images, linking out to the nuget page.