### PR TITLE
GitHub Raw External Provider

### DIFF
--- a/Mocale.sln
+++ b/Mocale.sln
@@ -29,6 +29,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Generators", "Generators", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mocale.SourceGenerators", "src\Mocale.SourceGenerators\Mocale.SourceGenerators.csproj", "{3CC5AC06-A29D-4C08-B73F-6A9EC9158125}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mocale.Providers.GitHub.Raw", "src\Mocale.Providers.GitHub.Raw\Mocale.Providers.GitHub.Raw.csproj", "{F97214BB-15F0-449B-88F1-CABE89ACB3F8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,6 +61,10 @@ Global
 		{3CC5AC06-A29D-4C08-B73F-6A9EC9158125}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3CC5AC06-A29D-4C08-B73F-6A9EC9158125}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3CC5AC06-A29D-4C08-B73F-6A9EC9158125}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F97214BB-15F0-449B-88F1-CABE89ACB3F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F97214BB-15F0-449B-88F1-CABE89ACB3F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F97214BB-15F0-449B-88F1-CABE89ACB3F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F97214BB-15F0-449B-88F1-CABE89ACB3F8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -72,5 +78,6 @@ Global
 		{857B40AB-FFA9-4AF3-A27A-3F1CC66130E8} = {D3CFAD31-519D-41F6-80AA-38E209378B59}
 		{39A66F28-2521-4838-825F-7601632CD0B1} = {40F3C130-0713-4EE4-BA11-93AAD3EF6DFA}
 		{3CC5AC06-A29D-4C08-B73F-6A9EC9158125} = {98375271-AB1B-4201-817F-350BBF4F9E9F}
+		{F97214BB-15F0-449B-88F1-CABE89ACB3F8} = {D3CFAD31-519D-41F6-80AA-38E209378B59}
 	EndGlobalSection
 EndGlobal

--- a/samples/Locales/en-GB.json
+++ b/samples/Locales/en-GB.json
@@ -1,0 +1,7 @@
+{
+  "CurrentLocaleName": "English",
+  "LocalizationCurrentProviderIs": "GR_The current localization provider is:",
+  "LocalizationProviderName": "GR_Json",
+  "MocaleDescription": "GR_Localization framework for .NET Maui",
+  "MocaleTitle": "GR_Mocale"
+}

--- a/samples/Locales/fr-FR.json
+++ b/samples/Locales/fr-FR.json
@@ -1,0 +1,7 @@
+{
+  "CurrentLocaleName": "French",
+  "LocalizationCurrentProviderIs": "GR_Le fournisseur de localisation actuel est:",
+  "LocalizationProviderName": "GR_Json",
+  "MocaleDescription": "GR_Framework de localisation pour .NET Maui",
+  "MocaleTitle": "GR_Mocale"
+}

--- a/samples/Mocale.Samples.sln
+++ b/samples/Mocale.Samples.sln
@@ -40,6 +40,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{23D0CB27
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mocale.UnitTests", "..\tests\Mocale.UnitTests\Mocale.UnitTests.csproj", "{04F9CE7A-4E0E-4DDD-9730-1BC6348559EF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mocale.Providers.GitHub.Raw", "..\src\Mocale.Providers.GitHub.Raw\Mocale.Providers.GitHub.Raw.csproj", "{DE6A22FD-CAAA-4FD0-896D-066ABC5AFBAB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -80,6 +82,10 @@ Global
 		{04F9CE7A-4E0E-4DDD-9730-1BC6348559EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{04F9CE7A-4E0E-4DDD-9730-1BC6348559EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{04F9CE7A-4E0E-4DDD-9730-1BC6348559EF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE6A22FD-CAAA-4FD0-896D-066ABC5AFBAB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE6A22FD-CAAA-4FD0-896D-066ABC5AFBAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE6A22FD-CAAA-4FD0-896D-066ABC5AFBAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE6A22FD-CAAA-4FD0-896D-066ABC5AFBAB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -96,6 +102,7 @@ Global
 		{53D19643-B966-44A1-8D13-20FB63D1A255} = {AEF022DA-558F-432C-A6D3-1520EABBD3B3}
 		{8F1A039F-2FEA-4C3B-BD0C-598F93A2BE8B} = {30608F13-5526-4C56-AB32-8123BC2A8D9C}
 		{04F9CE7A-4E0E-4DDD-9730-1BC6348559EF} = {23D0CB27-546A-43F3-B467-04D2A4672D81}
+		{DE6A22FD-CAAA-4FD0-896D-066ABC5AFBAB} = {0B693BD4-B0C5-4448-9784-8839869C7371}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {61F7FB11-1E47-470C-91E2-47F8143E1572}

--- a/samples/Mocale.Samples/MauiProgram.cs
+++ b/samples/Mocale.Samples/MauiProgram.cs
@@ -33,7 +33,7 @@ public static class MauiProgram
                     {
                         config.Username = "Axemasta";
                         config.Repository = "Mocale";
-                        config.Branch = "github-provider";
+                        config.Branch = "main";
                         config.LocaleDirectory = "samples/Locales/";
                     });
             })

--- a/samples/Mocale.Samples/MauiProgram.cs
+++ b/samples/Mocale.Samples/MauiProgram.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Mocale.Cache.SQLite;
-using Mocale.Providers.Azure.Blob;
+using Mocale.Providers.GitHub.Raw;
 using Mocale.Samples.ViewModels;
 using Mocale.Samples.Views;
 namespace Mocale.Samples;
@@ -20,10 +20,6 @@ public static class MauiProgram
                         config.DefaultCulture = new CultureInfo("en-GB");
                         config.NotFoundSymbol = "?";
                     })
-                    //.UseAppResources(config =>
-                    //{
-                    //    config.AppResourcesType = typeof(AppResources);
-                    //})
                     .UseSqliteCache(config =>
                     {
                         config.UpdateInterval = TimeSpan.FromDays(7);
@@ -33,16 +29,13 @@ public static class MauiProgram
                         config.ResourcesPath = "Locales";
                         config.ResourcesAssembly = typeof(App).Assembly;
                     })
-                    .UseBlobStorage(config =>
+                    .UseGitHubRaw(config =>
                     {
-                        config.BlobContainerUri = new Uri("https://azurestorage/mocale/");
-                        config.RequiresAuthentication = false;
-                        config.CheckForFile = true;
+                        config.Username = "Axemasta";
+                        config.Repository = "Mocale";
+                        config.Branch = "github-provider";
+                        config.LocaleDirectory = "samples/Locales/";
                     });
-                //.UseS3Bucket(config =>
-                //{
-                //    config.BucketUri = new Uri("https://aws.com/mocale/");
-                //});
             })
             .ConfigureFonts(fonts =>
             {

--- a/samples/Mocale.Samples/Mocale.Samples.csproj
+++ b/samples/Mocale.Samples/Mocale.Samples.csproj
@@ -66,6 +66,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Mocale.Cache.SQLite\Mocale.Cache.SQLite.csproj" />
+    <ProjectReference Include="..\..\src\Mocale.Providers.GitHub.Raw\Mocale.Providers.GitHub.Raw.csproj" />
     <ProjectReference Include="..\..\src\Mocale.SourceGenerators\Mocale.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\src\Mocale.Providers.Aws.S3\Mocale.Providers.AWS.S3.csproj" />
     <ProjectReference Include="..\..\src\Mocale.Providers.Azure.Blob\Mocale.Providers.Azure.Blob.csproj" />

--- a/samples/Mocale.Samples/Resources/Locales/en-GB.json
+++ b/samples/Mocale.Samples/Resources/Locales/en-GB.json
@@ -3,5 +3,6 @@
   "LocalizationCurrentProviderIs": "The current localization provider is:",
   "LocalizationProviderName": "Json",
   "MocaleDescription": "Localization framework for .NET Maui",
-  "MocaleTitle": "Mocale"
+  "MocaleTitle": "Mocale",
+  "ExternalPrefixExplanation": "Strings prefixed with GR_ indicate they have been pulled from the external provider (GitHub.Raw), when the local cache expires if these values change, so will the text displayed!"
 }

--- a/samples/Mocale.Samples/Resources/Locales/fr-FR.json
+++ b/samples/Mocale.Samples/Resources/Locales/fr-FR.json
@@ -3,5 +3,6 @@
   "LocalizationCurrentProviderIs": "Le fournisseur de localisation actuel est:",
   "LocalizationProviderName": "Json",
   "MocaleDescription": "Framework de localisation pour .NET Maui",
-  "MocaleTitle": "Mocale"
+  "MocaleTitle": "Mocale",
+  "ExternalPrefixExplanation": "Strings prefixed with GR_ indicate they have been pulled from the external provider (GitHub.Raw), when the local cache expires if these values change, so will the text displayed!"
 }

--- a/samples/Mocale.Samples/Views/IntroductionPage.xaml
+++ b/samples/Mocale.Samples/Views/IntroductionPage.xaml
@@ -19,6 +19,7 @@
     <VerticalStackLayout
         HorizontalOptions="Center"
         Spacing="10"
+        Padding="20, 0"
         VerticalOptions="Center">
         <Label Text="{mocale:Localize Key={x:Static keys:TranslationKeys.CurrentLocaleName}, Converter={StaticResource LanguageEmojiConverter}}" />
 
@@ -38,5 +39,11 @@
         <Picker ItemsSource="{Binding Locales}" SelectedItem="{Binding SelectedLocale}" />
 
         <Label Text="{mocale:Localize LoadedTranslation}" />
+
+        <Label
+            Margin="0,20,0,0"
+            FontAttributes="Italic"
+            FontSize="Small"
+            Text="{mocale:Localize Key={x:Static keys:TranslationKeys.ExternalPrefixExplanation}}"/>
     </VerticalStackLayout>
 </ContentPage>

--- a/src/Mocale.Providers.GitHub.Raw/Abstractions/IGithubRawConfig.cs
+++ b/src/Mocale.Providers.GitHub.Raw/Abstractions/IGithubRawConfig.cs
@@ -8,5 +8,5 @@ public interface IGithubRawConfig
 
     string Branch { get; }
 
-    string? LocaleDirectory { get; }
+    string LocaleDirectory { get; }
 }

--- a/src/Mocale.Providers.GitHub.Raw/Abstractions/IGithubRawConfig.cs
+++ b/src/Mocale.Providers.GitHub.Raw/Abstractions/IGithubRawConfig.cs
@@ -1,0 +1,12 @@
+namespace Mocale.Providers.GitHub.Raw.Abstractions;
+
+public interface IGithubRawConfig
+{
+    string Username { get; }
+
+    string Repository { get; }
+
+    string Branch { get; }
+
+    string? LocaleDirectory { get; }
+}

--- a/src/Mocale.Providers.GitHub.Raw/GitHubRawProvider.cs
+++ b/src/Mocale.Providers.GitHub.Raw/GitHubRawProvider.cs
@@ -1,5 +1,9 @@
+using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Net.Http;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Ardalis.GuardClauses;
 using Mocale.Helper;
 using Mocale.Providers.GitHub.Raw.Helpers;
@@ -12,18 +16,23 @@ internal class GitHubRawProvider : IExternalLocalizationProvider
     private readonly IGithubRawConfig githubConfig;
     private readonly ILogger logger;
 
+    private readonly HttpClient httpClient;
+
     #endregion Fields
 
     #region Constructors
 
     public GitHubRawProvider(
         IConfigurationManager<IGithubRawConfig> githubConfigurationManager,
+        IHttpClientFactory httpClientFactory,
         ILogger<GitHubRawProvider> logger)
     {
         githubConfigurationManager = Guard.Against.Null(githubConfigurationManager, nameof(githubConfigurationManager));
 
         this.githubConfig = githubConfigurationManager.Configuration;
         this.logger = Guard.Against.Null(logger, nameof(logger));
+
+        httpClient = httpClientFactory.CreateClient("Mocale.Providers.GitHub.Raw");
     }
 
     #endregion Constructors
@@ -37,8 +46,6 @@ internal class GitHubRawProvider : IExternalLocalizationProvider
 
     private async Task<IExternalLocalizationResult> QueryResourceUrlForLocalizations(Uri resourceUri)
     {
-        using var httpClient = new HttpClient();
-
         try
         {
             var response = await httpClient.GetAsync(resourceUri);

--- a/src/Mocale.Providers.GitHub.Raw/GitHubRawProvider.cs
+++ b/src/Mocale.Providers.GitHub.Raw/GitHubRawProvider.cs
@@ -24,15 +24,14 @@ internal class GitHubRawProvider : IExternalLocalizationProvider
 
     public GitHubRawProvider(
         IConfigurationManager<IGithubRawConfig> githubConfigurationManager,
-        IHttpClientFactory httpClientFactory,
+        HttpClient httpClient,
         ILogger<GitHubRawProvider> logger)
     {
         githubConfigurationManager = Guard.Against.Null(githubConfigurationManager, nameof(githubConfigurationManager));
 
         this.githubConfig = githubConfigurationManager.Configuration;
+        this.httpClient = Guard.Against.Null(httpClient, nameof(httpClient));
         this.logger = Guard.Against.Null(logger, nameof(logger));
-
-        httpClient = httpClientFactory.CreateClient("Mocale.Providers.GitHub.Raw");
     }
 
     #endregion Constructors

--- a/src/Mocale.Providers.GitHub.Raw/GitHubRawProvider.cs
+++ b/src/Mocale.Providers.GitHub.Raw/GitHubRawProvider.cs
@@ -1,0 +1,63 @@
+using System.Globalization;
+using Ardalis.GuardClauses;
+using Mocale.Helper;
+namespace Mocale.Providers.GitHub.Raw;
+
+internal class GitHubRawProvider : IExternalLocalizationProvider
+{
+    #region Fields
+
+    private readonly IGithubRawConfig githubConfig;
+    private readonly ILogger logger;
+
+    #endregion Fields
+
+    #region Constructors
+
+    public GitHubRawProvider(
+        IConfigurationManager<IGithubRawConfig> githubConfigurationManager,
+        ILogger<GitHubRawProvider> logger)
+    {
+        githubConfigurationManager = Guard.Against.Null(githubConfigurationManager, nameof(githubConfigurationManager));
+
+        this.githubConfig = githubConfigurationManager.Configuration;
+        this.logger = Guard.Against.Null(logger, nameof(logger));
+    }
+
+    #endregion Constructors
+
+    public async Task<IExternalLocalizationResult> GetValuesForCultureAsync(CultureInfo cultureInfo)
+    {
+        var fileName = ExternalResourceHelper.GetExpectedJsonFileName(cultureInfo, null);
+
+        var baseUrl = "https://raw.githubusercontent.com/Axemasta/Mocale/github-provider/samples/Locales/";
+
+        var fullUrl = Path.Combine(baseUrl, fileName);
+
+        using var httpClient = new HttpClient();
+
+        try
+        {
+            var response = await httpClient.GetAsync(fullUrl);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                // Handle Error
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+
+            Console.WriteLine(content);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+            throw;
+        }
+
+        return new ExternalLocalizationResult()
+        {
+            Success = false,
+        };
+    }
+}

--- a/src/Mocale.Providers.GitHub.Raw/Helpers/RawUrlBuilder.cs
+++ b/src/Mocale.Providers.GitHub.Raw/Helpers/RawUrlBuilder.cs
@@ -1,0 +1,12 @@
+using Mocale.Extensions;
+namespace Mocale.Providers.GitHub.Raw.Helpers;
+
+internal static class RawUrlBuilder
+{
+    public static Uri BuildResourceUrl(string username, string repository, string branch, string filePath, string fileName)
+    {
+        // https://raw.githubusercontent.com/Axemasta/Mocale/github-provider/samples/Locales/fr-FR.json
+        return new Uri("https://raw.githubusercontent.com/")
+            .Append(username, repository, branch, filePath, fileName);
+    }
+}

--- a/src/Mocale.Providers.GitHub.Raw/Mocale.Providers.GitHub.Raw.csproj
+++ b/src/Mocale.Providers.GitHub.Raw/Mocale.Providers.GitHub.Raw.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+        <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
+        <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
+        <UseMaui>true</UseMaui>
+        <SingleProject>true</SingleProject>
+
+        <AssemblyName>Mocale.Providers.Github.Raw</AssemblyName>
+        <RootNamespace>Mocale.Providers.Github.Raw</RootNamespace>
+        <PackageId>Mocale.Providers.Github.Raw</PackageId>
+        <Summary>GitHub Raw Provider For Mocale</Summary>
+        <PackageTag>maui,mocale,localization,localisation,translation,github,raw,githubraw,provider,mocaleprovider</PackageTag>
+        <Title>Mocale.Providers.GitHub.Raw</Title>
+        <Description>GitHub raw external provider for Mocale. This package will attempt to use the configured GitHub repository to download localizations to be used in your maui application.</Description>
+        <Authors>Axemasta</Authors>
+        <Owners>Axemasta</Owners>
+        <NeutralLanguage>en</NeutralLanguage>
+        <RepositoryUrl>https://github.com/Axemasta/Mocale</RepositoryUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+        <PackageProjectUrl>https://github.com/Axemasta/Mocale</PackageProjectUrl>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+      
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
+        <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
+    </PropertyGroup>
+  
+    <ItemGroup>
+      <ProjectReference Include="..\Mocale\Mocale.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Mocale.Providers.GitHub.Raw/Mocale.Providers.GitHub.Raw.csproj
+++ b/src/Mocale.Providers.GitHub.Raw/Mocale.Providers.GitHub.Raw.csproj
@@ -35,5 +35,9 @@
     <ItemGroup>
       <ProjectReference Include="..\Mocale\Mocale.csproj" />
     </ItemGroup>
+  
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+    </ItemGroup>
 
 </Project>

--- a/src/Mocale.Providers.GitHub.Raw/Mocale.Providers.GitHub.Raw.csproj
+++ b/src/Mocale.Providers.GitHub.Raw/Mocale.Providers.GitHub.Raw.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
+        <TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
         <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
         <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
         <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->

--- a/src/Mocale.Providers.GitHub.Raw/MocaleBuilderExtension.cs
+++ b/src/Mocale.Providers.GitHub.Raw/MocaleBuilderExtension.cs
@@ -4,7 +4,7 @@ namespace Mocale.Providers.GitHub.Raw;
 
 public static class MocaleBuilderExtension
 {
-    public static MocaleBuilder UseGitHubRaw(this MocaleBuilder builder, Action<GithubRawConfig> configureGithub)
+    public static MocaleBuilder UseGitHubRaw(this MocaleBuilder builder, Action<GithubRawConfig> configureGithub, Action<HttpClient>? configureHttpClient = null)
     {
         builder.RegisterExternalProvider(typeof(GitHubRawProvider));
 
@@ -15,7 +15,15 @@ public static class MocaleBuilderExtension
 
         builder.AppBuilder.Services.AddSingleton<IConfigurationManager<IGithubRawConfig>>(configurationManager);
         builder.AppBuilder.Services.AddSingleton<IExternalLocalizationProvider, GitHubRawProvider>();
-        builder.AppBuilder.Services.AddHttpClient();
+
+        if (configureHttpClient is not null)
+        {
+            builder.AppBuilder.Services.AddHttpClient<IExternalLocalizationProvider, GitHubRawProvider>(configureHttpClient);
+        }
+        else
+        {
+            builder.AppBuilder.Services.AddHttpClient<IExternalLocalizationProvider, GitHubRawProvider>();
+        }
 
         return builder;
     }

--- a/src/Mocale.Providers.GitHub.Raw/MocaleBuilderExtension.cs
+++ b/src/Mocale.Providers.GitHub.Raw/MocaleBuilderExtension.cs
@@ -1,9 +1,21 @@
+using Mocale.Managers;
+
 namespace Mocale.Providers.GitHub.Raw;
 
 public static class MocaleBuilderExtension
 {
-    public static MocaleBuilder UseGitHubRawProvider(this MocaleBuilder builder, Action<GithubRawConfig> configureGithub)
+    public static MocaleBuilder UseGitHubRaw(this MocaleBuilder builder, Action<GithubRawConfig> configureGithub)
     {
+        builder.RegisterExternalProvider(typeof(GitHubRawProvider));
+
+        var config = new GithubRawConfig();
+        configureGithub(config);
+
+        var configurationManager = new ConfigurationManager<IGithubRawConfig>(config);
+
+        builder.AppBuilder.Services.AddSingleton<IConfigurationManager<IGithubRawConfig>>(configurationManager);
+        builder.AppBuilder.Services.AddSingleton<IExternalLocalizationProvider, GitHubRawProvider>();
+
         return builder;
     }
 }

--- a/src/Mocale.Providers.GitHub.Raw/MocaleBuilderExtension.cs
+++ b/src/Mocale.Providers.GitHub.Raw/MocaleBuilderExtension.cs
@@ -15,6 +15,7 @@ public static class MocaleBuilderExtension
 
         builder.AppBuilder.Services.AddSingleton<IConfigurationManager<IGithubRawConfig>>(configurationManager);
         builder.AppBuilder.Services.AddSingleton<IExternalLocalizationProvider, GitHubRawProvider>();
+        builder.AppBuilder.Services.AddHttpClient();
 
         return builder;
     }

--- a/src/Mocale.Providers.GitHub.Raw/MocaleBuilderExtension.cs
+++ b/src/Mocale.Providers.GitHub.Raw/MocaleBuilderExtension.cs
@@ -1,0 +1,9 @@
+namespace Mocale.Providers.GitHub.Raw;
+
+public static class MocaleBuilderExtension
+{
+    public static MocaleBuilder UseGitHubRawProvider(this MocaleBuilder builder, Action<GithubRawConfig> configureGithub)
+    {
+        return builder;
+    }
+}

--- a/src/Mocale.Providers.GitHub.Raw/Models/GithubRawConfig.cs
+++ b/src/Mocale.Providers.GitHub.Raw/Models/GithubRawConfig.cs
@@ -1,6 +1,7 @@
+using Mocale.Providers.GitHub.Raw.Abstractions;
 namespace Mocale.Providers.GitHub.Raw.Models;
 
-public class GithubRawConfig
+public class GithubRawConfig : IGithubRawConfig
 {
     public string Username { get; set; } = string.Empty;
 

--- a/src/Mocale.Providers.GitHub.Raw/Models/GithubRawConfig.cs
+++ b/src/Mocale.Providers.GitHub.Raw/Models/GithubRawConfig.cs
@@ -9,5 +9,5 @@ public class GithubRawConfig : IGithubRawConfig
 
     public string Branch { get; set; } = "main";
 
-    public string? LocaleDirectory { get; set; }
+    public string LocaleDirectory { get; set; } = string.Empty;
 }

--- a/src/Mocale.Providers.GitHub.Raw/Models/GithubRawConfig.cs
+++ b/src/Mocale.Providers.GitHub.Raw/Models/GithubRawConfig.cs
@@ -1,0 +1,12 @@
+namespace Mocale.Providers.GitHub.Raw.Models;
+
+public class GithubRawConfig
+{
+    public string Username { get; set; } = string.Empty;
+
+    public string Repository { get; set; } = string.Empty;
+
+    public string Branch { get; set; } = "main";
+
+    public string? LocaleDirectory { get; set; }
+}

--- a/src/Mocale.Providers.GitHub.Raw/Properties/GlobalSuppression.cs
+++ b/src/Mocale.Providers.GitHub.Raw/Properties/GlobalSuppression.cs
@@ -1,0 +1,6 @@
+// This file is used by Code Analysis to maintain SuppressMessage attributes that are applied to
+// this project. Project-level suppressions either have no target or are given a specific target and
+// scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+[assembly: SuppressMessage("Performance", "CA1848:Use the LoggerMessage delegates", Justification = "This message is annoying, why provide methods we can't use?")]

--- a/src/Mocale.Providers.GitHub.Raw/Properties/GlobalUsings.cs
+++ b/src/Mocale.Providers.GitHub.Raw/Properties/GlobalUsings.cs
@@ -1,0 +1,3 @@
+global using Mocale.Abstractions;
+global using Mocale.Models;
+global using Mocale.Providers.GitHub.Raw.Models;

--- a/src/Mocale.Providers.GitHub.Raw/Properties/GlobalUsings.cs
+++ b/src/Mocale.Providers.GitHub.Raw/Properties/GlobalUsings.cs
@@ -1,3 +1,5 @@
 global using Mocale.Abstractions;
 global using Mocale.Models;
+global using Mocale.Providers.GitHub.Raw.Abstractions;
 global using Mocale.Providers.GitHub.Raw.Models;
+global using Microsoft.Extensions.Logging;

--- a/src/Mocale/Mocale.csproj
+++ b/src/Mocale/Mocale.csproj
@@ -33,16 +33,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="$(AssemblyName).Json"/>
-    <InternalsVisibleTo Include="$(AssemblyName).Resx"/>
     <InternalsVisibleTo Include="$(AssemblyName).Providers.AWS.S3"/>
     <InternalsVisibleTo Include="$(AssemblyName).Providers.Azure.Blob"/>
+    <InternalsVisibleTo Include="$(AssemblyName).Providers.GitHub.Raw"/>
     <InternalsVisibleTo Include="$(AssemblyName).Cache.SQLite"/>
     <InternalsVisibleTo Include="$(AssemblyName).UnitTests"/>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Remove="Microsoft.Extensions.Logging.Abstractions"/>
   </ItemGroup>
 
 </Project>

--- a/src/directory.build.props
+++ b/src/directory.build.props
@@ -4,6 +4,10 @@
     <ImplicitUsings>true</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <InternalsVisibleTo Include="Mocale.UnitTests"/>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1"/>

--- a/src/directory.build.props
+++ b/src/directory.build.props
@@ -4,9 +4,10 @@
     <ImplicitUsings>true</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <InternalsVisibleTo Include="Mocale.UnitTests"/>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Mocale.UnitTests/Helpers/RawUrlBuilderTests.cs
+++ b/tests/Mocale.UnitTests/Helpers/RawUrlBuilderTests.cs
@@ -1,0 +1,34 @@
+
+using Mocale.Providers.GitHub.Raw.Helpers;
+namespace Mocale.UnitTests.Helpers;
+
+public class RawUrlBuilderTests
+{
+    [Theory]
+    [InlineData(
+        "Axemasta", "Mocale",
+        "main", "samples/Locales",
+        "en-GB.json", "https://raw.githubusercontent.com/Axemasta/Mocale/main/samples/Locales/en-GB.json")]
+    [InlineData(
+        "Axemasta", "Mocale",
+        "main", "samples/Locales",
+        "fr-FR.json", "https://raw.githubusercontent.com/Axemasta/Mocale/main/samples/Locales/fr-FR.json")]
+    [InlineData(
+        "Axemasta", "Mocale",
+        "develop", "samples/Locales",
+        "en-GB.json", "https://raw.githubusercontent.com/Axemasta/Mocale/develop/samples/Locales/en-GB.json")]
+    [InlineData(
+        "Axemasta", "Mocale",
+        "develop", "samples/Locales",
+        "fr-FR.json", "https://raw.githubusercontent.com/Axemasta/Mocale/develop/samples/Locales/fr-FR.json")]
+    public void TryBuildResourceUrl_WhenProvidedValues_ShouldReturnSuccess(string username, string repository, string branch, string filePath, string fileName, string expectedUrl)
+    {
+        // Arrange
+
+        // Act
+        var result = RawUrlBuilder.BuildResourceUrl(username, repository, branch, filePath, fileName);
+
+        // Assert
+        Assert.Equal(expectedUrl, result.ToString());
+    }
+}

--- a/tests/Mocale.UnitTests/Managers/LocalizationManagerTests.cs
+++ b/tests/Mocale.UnitTests/Managers/LocalizationManagerTests.cs
@@ -350,6 +350,10 @@ public class LocalizationManagerTests : FixtureBase<ILocalizationManager>
         // Act
         var initialized = await Sut.Initialize();
 
+        // Small delay to reduce test flake on CI due to fire & forget call
+        // maybe this is tech debt?
+        await Task.Delay(50);
+
         // Assert
         Assert.True(initialized);
 

--- a/tests/Mocale.UnitTests/Mocale.UnitTests.csproj
+++ b/tests/Mocale.UnitTests/Mocale.UnitTests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="ILogger.Moq" Version="1.1.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Mocale.UnitTests/Mocale.UnitTests.csproj
+++ b/tests/Mocale.UnitTests/Mocale.UnitTests.csproj
@@ -29,7 +29,8 @@
     <ProjectReference Include="..\..\src\Mocale.Cache.SQLite\Mocale.Cache.SQLite.csproj" />
     <ProjectReference Include="..\..\src\Mocale.Providers.Aws.S3\Mocale.Providers.AWS.S3.csproj" />
     <ProjectReference Include="..\..\src\Mocale.Providers.Azure.Blob\Mocale.Providers.Azure.Blob.csproj" />
+    <ProjectReference Include="..\..\src\Mocale.Providers.Github.Raw\Mocale.Providers.Github.Raw.csproj" />
     <ProjectReference Include="..\..\src\Mocale\Mocale.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/tests/Mocale.UnitTests/Providers/GitHubRawProviderTests.cs
+++ b/tests/Mocale.UnitTests/Providers/GitHubRawProviderTests.cs
@@ -1,0 +1,88 @@
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+using Mocale.Abstractions;
+using Mocale.Providers.GitHub.Raw;
+using Mocale.Providers.GitHub.Raw.Abstractions;
+using Mocale.Providers.GitHub.Raw.Models;
+using Moq.Contrib.HttpClient;
+namespace Mocale.UnitTests.Providers;
+
+public class GitHubRawProviderTests : FixtureBase<IExternalLocalizationProvider>
+{
+    #region Setup
+
+    private readonly Mock<IConfigurationManager<IGithubRawConfig>> configurationManager;
+    private readonly Mock<HttpMessageHandler> httpMessageHandler;
+    private readonly Mock<ILogger<GitHubRawProvider>> logger;
+
+    #region Constructors
+
+    public GitHubRawProviderTests()
+    {
+        configurationManager = new Mock<IConfigurationManager<IGithubRawConfig>>();
+        httpMessageHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        logger = new Mock<ILogger<GitHubRawProvider>>();
+    }
+
+    #endregion Constructors
+
+    public override IExternalLocalizationProvider CreateSystemUnderTest()
+    {
+        return new GitHubRawProvider(
+            configurationManager.Object,
+            new HttpClient(httpMessageHandler.Object),
+            logger.Object);
+    }
+
+    #endregion Setup
+
+    #region Tests
+
+    [Fact]
+    public async Task GetValuesForCultureAsync_WhenResourceExistAndIsValidLocalization_ShouldDeserializeAndReturnSuccess()
+    {
+        // Arrange
+        var newCulture = new CultureInfo("en-GB");
+
+        configurationManager.SetupGet(m => m.Configuration)
+            .Returns(new GithubRawConfig()
+            {
+                Username = "Axemasta",
+                Repository = "Mocale",
+                Branch = "main",
+                LocaleDirectory = "samples/Locales",
+            });
+
+        var rawJson = """
+            {
+              "CurrentLocaleName": "English",
+              "LocalizationCurrentProviderIs": "GR_The current localization provider is:",
+              "LocalizationProviderName": "GR_Json",
+              "MocaleDescription": "GR_Localization framework for .NET Maui",
+              "MocaleTitle": "GR_Mocale"
+            }
+            """;
+
+        httpMessageHandler.SetupRequest(HttpMethod.Get, "https://raw.githubusercontent.com/Axemasta/Mocale/main/samples/Locales/en-GB.json")
+            .ReturnsResponse(rawJson);
+
+        // Act
+        var result = await Sut.GetValuesForCultureAsync(newCulture);
+
+        // Assert
+        Assert.True(result.Success);
+
+        var expectedLocalizations = new Dictionary<string, string>()
+        {
+            { "CurrentLocaleName", "English" },
+            { "LocalizationCurrentProviderIs", "GR_The current localization provider is:" },
+            { "LocalizationProviderName", "GR_Json" },
+            { "MocaleDescription", "GR_Localization framework for .NET Maui" },
+            { "MocaleTitle", "GR_Mocale" },
+        };
+
+        result.Localizations.Should().BeEquivalentTo(expectedLocalizations);
+    }
+
+    #endregion Tests
+}


### PR DESCRIPTION
Created a new external provider for the GitHub raw api.

This allows users to host their localizations within their github repository. There is config for where the file is located and even httpclient configuration should you required it (for example setting proxies).

I haven't added documentation but i think the need for a proper wiki is in order so I will hold off. For the time being look at my sample, its quite straight forward. Anther positive is that the sample now works out of the box (before you needed to provide an azure blob container).