### PR TITLE
Add Skip Duplicate To Release Action

### DIFF
--- a/.github/workflows/mocale-release.yml
+++ b/.github/workflows/mocale-release.yml
@@ -98,4 +98,4 @@ jobs:
         body: ${{ inputs.release-notes }}
 
     - name: Publish NuGet
-      run: nuget push ${{ inputs.artifacts }} -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{ secrets.NUGET_API_KEY }}
+      run: nuget push ${{ inputs.artifacts }} -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{ secrets.NUGET_API_KEY }} -SkipDuplicate


### PR DESCRIPTION
This is really awkward to manage when creating a new package, this should hopefully make the manual process a bit less tedious