### PR TITLE
Switch Source Generator To Newtonsoft

### DIFF
--- a/src/Mocale.SourceGenerators/LocalizationKeySourceGenerator.cs
+++ b/src/Mocale.SourceGenerators/LocalizationKeySourceGenerator.cs
@@ -1,10 +1,10 @@
 using System.Collections.Immutable;
 using System.Text;
-using System.Text.Json;
 using System.Text.RegularExpressions;
 using Humanizer;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Newtonsoft.Json;
 
 namespace Mocale.SourceGenerators;
 
@@ -42,7 +42,7 @@ public class LocalizationKeySourceGenerator : IIncrementalGenerator
         {
             try
             {
-                var translations = JsonSerializer.Deserialize<Dictionary<string, string>>(translationJson);
+                var translations = JsonConvert.DeserializeObject<Dictionary<string, string>>(translationJson);
 
                 if (translations is null)
                 {

--- a/src/Mocale.SourceGenerators/Mocale.SourceGenerators.csproj
+++ b/src/Mocale.SourceGenerators/Mocale.SourceGenerators.csproj
@@ -23,11 +23,11 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" PrivateAssets="all"/>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all"/>
     <PackageReference Include="Humanizer.Core" Version="2.10.1" PrivateAssets="all" GeneratePathProperty="true"/>
-    <PackageReference Include="System.Text.Encodings.Web" Version="7.0.0" PrivateAssets="all" GeneratePathProperty="true"/>
-    <PackageReference Include="System.Text.Json" Version="7.0.3" PrivateAssets="all" GeneratePathProperty="true"/>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" PrivateAssets="all" GeneratePathProperty="true"/>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" PrivateAssets="all" GeneratePathProperty="true" />
 
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
+
+    <None Include="$(PkgNewtonsoft_Json)\lib\netstandard2.0\*.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -37,9 +37,7 @@
   <Target Name="GetDependencyTargetPaths">
     <ItemGroup>
       <TargetPathWithTargetPlatformMoniker Include="$(PKGHumanizer_Core)\lib\netstandard2.0\Humanizer.dll" IncludeRuntimeDependency="false"/>
-      <TargetPathWithTargetPlatformMoniker Include="$(PKGSystem_Text_Json)\lib\netstandard2.0\System.Text.Json.dll" IncludeRuntimeDependency="false"/>
-      <TargetPathWithTargetPlatformMoniker Include="$(PKGMicrosoft_Bcl_AsyncInterfaces)\lib\netstandard2.0\Microsoft.Bcl.AsyncInterfaces.dll" IncludeRuntimeDependency="false"/>
-      <TargetPathWithTargetPlatformMoniker Include="$(PKGSystem_Text_Encodings_Web)\lib\netstandard2.0\System.Text.Encodings.Web.dll" IncludeRuntimeDependency="false"/>
+      <TargetPathWithTargetPlatformMoniker Include="$(PkgNewtonsoft_Json)\lib\netstandard2.0\Newtonsoft.Json.dll" IncludeRuntimeDependency="false"/>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
See #27, the source generation wasn't working when referencing the nuget package (local ref works perferctly).

Upon further inspection the following error is logged in visual studio:
```
Severity	Code	Description	Project	File	Line	Suppression State	Detail Description
Warning	CS8785	Generator 'LocalizationKeySourceGenerator' failed to generate source. It will not contribute to the output and compilation errors may occur as a result. Exception was of type 'FileNotFoundException' with message 'Could not load file or assembly 'System.Text.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. The system cannot find the file specified.'	Mocale.Samples (net7.0-android)	C:\Dev\GitHub\Mocale\samples\Mocale.Samples\CSC	1	Active	Generator threw the following exception:
'{0}'.
```

I took a look at fiddling with dependencies but after reading [this ](https://stackoverflow.com/questions/67071355/source-generators-dependencies-not-loaded-in-visual-studio) SO thread and seeing the utter headache ahead of me, I decided to keep it simple and replace `System.Text.Json` with `Newtonsoft.Json`. I'm trying to use the system package going forwards but with the multiple dependencies and difficulty tracking this issue down, I'd rather have a working package and a good nights sleep!

Tested working with a private nuget feed so going to release this fix.