### PR TITLE
Add InMemory Cache Provider

### DIFF
--- a/.github/workflows/mocale-ci.yml
+++ b/.github/workflows/mocale-ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --configuration Release
       - name: Test
-        run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage"
+        run: dotnet test --no-build --configuration Release --verbosity normal --collect:"XPlat Code Coverage"
         if: github.event_name == 'pull_request'
       - name: Publish Code Coverage To PR
         uses: 5monkeys/cobertura-action@v13

--- a/directory.packages.props
+++ b/directory.packages.props
@@ -1,9 +1,10 @@
 <Project>
-	<PropertyGroup>
-		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-	</PropertyGroup>
-	<ItemGroup>
-		<PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)"/>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
     <PackageVersion Include="ResXResourceReader.NetStandard" Version="1.3.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.2" />
     <PackageVersion Include="Azure.Core" Version="1.45.0" />
@@ -11,7 +12,7 @@
     <PackageVersion Include="sqlite-net-pcl" Version="1.9.172" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0"/>
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="CommunityToolkit.Maui" Version="11.1.0" />
@@ -20,6 +21,5 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
     <PackageVersion Include="Ardalis.GuardClauses" Version="5.0.0" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
-	</ItemGroup>
+  </ItemGroup>
 </Project>
-

--- a/samples/Mocale.Samples/MauiProgram.cs
+++ b/samples/Mocale.Samples/MauiProgram.cs
@@ -34,10 +34,10 @@ public static class MauiProgram
                             AttributePropertyName = nameof(MocaleTranslationKeyAttribute.Key),
                         });
                     })
-                    .UseSqliteCache(config =>
-                    {
-                        config.UpdateInterval = TimeSpan.FromDays(1);
-                    })
+                    //.UseSqliteCache(config =>
+                    //{
+                    //    config.UpdateInterval = TimeSpan.FromDays(1);
+                    //})
                     .UseEmbeddedResources(config =>
                     {
                         config.ResourcesPath = "Locales";

--- a/src/Mocale.Cache.SQLite/MocaleBuilderExtension.cs
+++ b/src/Mocale.Cache.SQLite/MocaleBuilderExtension.cs
@@ -18,9 +18,14 @@ public static class MocaleBuilderExtension
     /// <returns></returns>
     public static MocaleBuilder UseSqliteCache(this MocaleBuilder builder, Action<SqliteConfig> configureSql)
     {
+        return UseSqliteCache(builder, FileSystem.Current, configureSql);
+    }
+
+    internal static MocaleBuilder UseSqliteCache(this MocaleBuilder builder, IFileSystem fileSystem, Action<SqliteConfig> configureSql)
+    {
         var config = new SqliteConfig
         {
-            DatabaseDirectory = FileSystem.AppDataDirectory,
+            DatabaseDirectory = fileSystem.AppDataDirectory,
         };
 
         configureSql(config);

--- a/src/Mocale/AppBuilderExtensions.cs
+++ b/src/Mocale/AppBuilderExtensions.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Caching.Memory;
+using Mocale.Cache;
 using Mocale.Exceptions;
 using Mocale.Managers;
 using Mocale.Providers;
@@ -68,8 +70,10 @@ public static class AppBuilderExtensions
 
         if (!mocaleBuilder.CacheProviderRegistered)
         {
-            // TODO: Initialize in memory provider
-            throw new InitializationException("No cache provider has been registered. In the future there will be an in memory provider, for now please install and register the SQLite cache provider");
+            mauiAppBuilder.Services.AddTransient<MemoryCache>();
+            mauiAppBuilder.Services.AddSingleton<InMemoryCacheManager>();
+            mauiAppBuilder.Services.AddSingleton<ILocalisationCacheManager>(x => x.GetRequiredService<InMemoryCacheManager>());
+            mauiAppBuilder.Services.AddSingleton<ICacheUpdateManager>(x => x.GetRequiredService<InMemoryCacheManager>());
         }
 
         return mauiAppBuilder;

--- a/src/Mocale/Cache/InMemoryCacheManager.cs
+++ b/src/Mocale/Cache/InMemoryCacheManager.cs
@@ -1,0 +1,44 @@
+using System.Globalization;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Mocale.Cache;
+
+internal class InMemoryCacheManager(MemoryCache memoryCache) : ILocalisationCacheManager, ICacheUpdateManager
+{
+    public bool CanUpdateCache(CultureInfo cultureInfo)
+    {
+        return !memoryCache.TryGetValue(cultureInfo, out _);
+    }
+
+    public void ClearCache(CultureInfo cultureInfo)
+    {
+        memoryCache.Remove(cultureInfo);
+    }
+
+    public void ClearCache()
+    {
+        memoryCache.Clear();
+    }
+
+    public Dictionary<string, string>? GetCachedLocalizations(CultureInfo cultureInfo)
+    {
+        if (memoryCache.TryGetValue<Dictionary<string, string>>(cultureInfo, out var cachedLocalizations))
+        {
+            return cachedLocalizations;
+        }
+
+        return null;
+    }
+
+    public bool SaveCachedLocalizations(CultureInfo cultureInfo, Dictionary<string, string> localizations)
+    {
+        memoryCache.Set(cultureInfo, localizations);
+
+        return true;
+    }
+
+    public bool SetCacheUpdated(CultureInfo cultureInfo)
+    {
+        return true;
+    }
+}

--- a/src/Mocale/Mocale.csproj
+++ b/src/Mocale/Mocale.csproj
@@ -25,7 +25,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ResXResourceReader.NetStandard" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" PrivateAssets="all" />
+    <PackageReference Include="ResXResourceReader.NetStandard" PrivateAssets="all"/>
   </ItemGroup>
 
 </Project>

--- a/src/Mocale/Mocale.csproj
+++ b/src/Mocale/Mocale.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" PrivateAssets="all" />
-    <PackageReference Include="ResXResourceReader.NetStandard" PrivateAssets="all"/>
+    <PackageReference Include="ResXResourceReader.NetStandard" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/directory.build.props
+++ b/src/directory.build.props
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses"/>
+    <PackageReference Include="Ardalis.GuardClauses" PrivateAssets="all"/>
     <PackageReference Include="Nerdbank.GitVersioning">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/tests/Mocale.UnitTests/Cache/InMemoryCacheManagerTests.cs
+++ b/tests/Mocale.UnitTests/Cache/InMemoryCacheManagerTests.cs
@@ -1,11 +1,5 @@
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Options;
 using Mocale.Cache;
 
 namespace Mocale.UnitTests.Cache;
@@ -79,11 +73,17 @@ public class InMemoryCacheManagerTests : FixtureBase, IDisposable
     public void ClearCache_CallsClearMethod()
     {
         // Arrange
+        memoryCache.Set(new CultureInfo("en-US"), new Dictionary<string, string>());
+        memoryCache.Set(new CultureInfo("en-GB"), new Dictionary<string, string>());
+        memoryCache.Set(new CultureInfo("fr-FR"), new Dictionary<string, string>());
+
+        Assert.Equal(3, memoryCache.Count);
 
         // Act
         GetSut<InMemoryCacheManager>().ClearCache();
 
         // Assert
+        Assert.Equal(0, memoryCache.Count);
     }
 
     [Fact]

--- a/tests/Mocale.UnitTests/Cache/InMemoryCacheManagerTests.cs
+++ b/tests/Mocale.UnitTests/Cache/InMemoryCacheManagerTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Mocale.Cache;
+
+namespace Mocale.UnitTests.Cache;
+
+public class InMemoryCacheManagerTests : FixtureBase, IDisposable
+{
+    #region Setup
+
+    private readonly MemoryCache memoryCache = new(new MemoryCacheOptions());
+
+    public override object CreateSystemUnderTest()
+    {
+        return new InMemoryCacheManager(memoryCache);
+    }
+
+    public void Dispose()
+    {
+        memoryCache?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    #endregion Setup
+
+    #region Tests
+
+    [Fact]
+    public void CanUpdateCache_WhenKeyNotInCache_ReturnsTrue()
+    {
+        // Arrange
+        var culture = new CultureInfo("en-US");
+
+        // Act
+        var result = GetSut<InMemoryCacheManager>().CanUpdateCache(culture);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void CanUpdateCache_WhenKeyInCache_ReturnsFalse()
+    {
+        // Arrange
+        var culture = new CultureInfo("en-US");
+        memoryCache.Set(culture, new Dictionary<string, string>()
+        {
+            { "KeyOne", "ValueOne" }
+        });
+
+        // Act
+        var result = GetSut<InMemoryCacheManager>().CanUpdateCache(culture);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ClearCache_RemovesCacheEntry()
+    {
+        // Arrange
+        var culture = new CultureInfo("en-US");
+        memoryCache.Set(culture, new Dictionary<string, string>());
+
+        // Act
+        GetSut<InMemoryCacheManager>().ClearCache(culture);
+
+        // Assert
+        Assert.False(memoryCache.TryGetValue(culture, out _));
+    }
+
+    [Fact]
+    public void ClearCache_CallsClearMethod()
+    {
+        // Arrange
+
+        // Act
+        GetSut<InMemoryCacheManager>().ClearCache();
+
+        // Assert
+    }
+
+    [Fact]
+    public void GetCachedLocalizations_WhenInCache_ReturnsDictionary()
+    {
+        // Arrange
+        var culture = new CultureInfo("en-US");
+        var localizations = new Dictionary<string, string> { { "Hello", "Hola" } };
+        memoryCache.Set(culture, localizations);
+
+        // Act
+        var result = GetSut<InMemoryCacheManager>().GetCachedLocalizations(culture);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Hola", result["Hello"]);
+    }
+
+    [Fact]
+    public void GetCachedLocalizations_WhenNotInCache_ReturnsNull()
+    {
+        // Arrange
+        var culture = new CultureInfo("en-US");
+
+        // Act
+        var result = GetSut<InMemoryCacheManager>().GetCachedLocalizations(culture);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void SaveCachedLocalizations_AddsEntryToCache()
+    {
+        // Arrange
+        var culture = new CultureInfo("en-US");
+        var localizations = new Dictionary<string, string> { { "Hello", "Hola" } };
+
+        // Act
+        var result = GetSut<InMemoryCacheManager>().SaveCachedLocalizations(culture, localizations);
+
+        // Assert
+        Assert.True(result);
+        Assert.True(memoryCache.TryGetValue(culture, out var cachedData));
+        Assert.Equal(localizations, cachedData);
+    }
+
+    [Fact]
+    public void SetCacheUpdated_AlwaysReturnsTrue()
+    {
+        // Arrange
+        var culture = new CultureInfo("en-US");
+
+        // Act
+        var result = GetSut<InMemoryCacheManager>().SetCacheUpdated(culture);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    #endregion Tests
+}

--- a/tests/Mocale.UnitTests/Extensions/AppBuilderExtensionsTests.cs
+++ b/tests/Mocale.UnitTests/Extensions/AppBuilderExtensionsTests.cs
@@ -1,0 +1,116 @@
+using Microsoft.Extensions.Caching.Memory;
+using Mocale.Abstractions;
+using Mocale.Cache;
+using Mocale.Cache.SQLite;
+using Mocale.Cache.SQLite.Managers;
+using Mocale.Exceptions;
+using Mocale.Managers;
+using Mocale.Models;
+using Mocale.Providers;
+using Mocale.UnitTests.TestHelpers;
+
+namespace Mocale.UnitTests.Extensions;
+
+public class AppBuilderExtensionsTests
+{
+    [Fact]
+    public void UseMocale_WhenNoLocalProviderRegistered_ShouldThrow()
+    {
+        // Arrange
+        var mauiAppBuilder = MauiApp.CreateBuilder();
+
+        // Act
+        var ex = Assert.Throws<InitializationException>(() => mauiAppBuilder.UseMocale(builder => { }));
+
+        // Assert
+        Assert.Equal("No local provider has been registered, please call either UseAppResources or UseEmbeddedResources in order to use mocale", ex.Message);
+    }
+
+    [Fact]
+    public void UseMocale_UseExternalProviderWithoutRegistration_ShouldThrow()
+    {
+        // Arrange
+        var mauiAppBuilder = MauiApp.CreateBuilder();
+
+        // Act & Assert
+        var exception = Assert.Throws<InitializationException>(() =>
+            mauiAppBuilder.UseMocale(builder =>
+            {
+                builder.UseEmbeddedResources(config => { });
+                builder.WithConfiguration(config =>
+                {
+                    config.UseExternalProvider = true;
+                });
+                builder.ExternalProviderRegistered = false;
+            })
+        );
+
+        Assert.Contains("No external provider was registered when mocale was configured to use one. Please register an external provider or set UseExternalProvider to false.", exception.Message);
+    }
+
+    [Fact]
+    public void UseMocale_NotUsingExternalProvider_ShouldRegisterInactiveProvider()
+    {
+        // Arrange
+        var mauiAppBuilder = MauiApp.CreateBuilder();
+
+        // Act
+        mauiAppBuilder.UseMocale(builder =>
+        {
+            builder.UseEmbeddedResources(config => { });
+            builder.WithConfiguration(config =>
+            {
+                config.UseExternalProvider = false;
+            });
+        });
+
+        // Assert
+        mauiAppBuilder.Services.ShouldContainImplementation<IExternalLocalizationProvider, InactiveExternalLocalizationProvider>();
+    }
+
+    [Fact]
+    public void UseMocale_WithCacheProvider_ShouldNotRegisterInMemoryCache()
+    {
+        // Arrange
+        var mauiAppBuilder = MauiApp.CreateBuilder();
+
+        // Act
+        mauiAppBuilder.UseMocale(builder =>
+        {
+            builder.UseEmbeddedResources(config => { });
+            builder.WithConfiguration(config =>
+            {
+                config.UseExternalProvider = false;
+            });
+            builder.UseSqliteCache(Mock.Of<IFileSystem>(), config => { });
+        });
+
+        // Assert
+        mauiAppBuilder.Services.ShouldNotContainImplementation<ILocalisationCacheManager, InMemoryCacheManager>();
+        mauiAppBuilder.Services.ShouldNotContainImplementation<ICacheUpdateManager, InMemoryCacheManager>();
+
+        mauiAppBuilder.Services.ShouldContainImplementation<ILocalisationCacheManager, LocalisationCacheManager>();
+        mauiAppBuilder.Services.ShouldContainImplementation<ICacheUpdateManager, SqlCacheUpdateManager>();
+    }
+
+    [Fact]
+    public void UseMocale_WithNoCacheProvider_ShouldRegisterInMemoryCache()
+    {
+        // Arrange
+        var mauiAppBuilder = MauiApp.CreateBuilder();
+
+        // Act
+        mauiAppBuilder.UseMocale(builder =>
+        {
+            builder.UseEmbeddedResources(config => { });
+            builder.WithConfiguration(config =>
+            {
+                config.UseExternalProvider = false;
+            });
+        });
+
+        // Assert
+        mauiAppBuilder.Services.ShouldContainImplementation<ILocalisationCacheManager, InMemoryCacheManager>();
+        mauiAppBuilder.Services.ShouldContainImplementation<ICacheUpdateManager, InMemoryCacheManager>();
+    }
+}

--- a/tests/Mocale.UnitTests/Mocale.UnitTests.csproj
+++ b/tests/Mocale.UnitTests/Mocale.UnitTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="ILogger.Moq" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Moq.Contrib.HttpClient"/>
+    <PackageReference Include="Moq.Contrib.HttpClient" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Mocale.UnitTests/Mocale.UnitTests.csproj
+++ b/tests/Mocale.UnitTests/Mocale.UnitTests.csproj
@@ -25,6 +25,9 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Moq" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
+    <PackageReference Include="Ardalis.GuardClauses" />
+    <PackageReference Include="ResXResourceReader.NetStandard" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Mocale.UnitTests/Properties/GlobalSuppressions.cs
+++ b/tests/Mocale.UnitTests/Properties/GlobalSuppressions.cs
@@ -8,3 +8,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test naming convention uses underscores")]
 [assembly: SuppressMessage("Performance", "CA1848:Use the LoggerMessage delegates", Justification = "This is a unit test project")]
 [assembly: SuppressMessage("Usage", "CA2201:Do not raise reserved exception types", Justification = "Unit tests will raise bogus exceptions for test cases")]
+[assembly: SuppressMessage("Globalization", "CA1304:Specify CultureInfo", Justification = "I'm explicitly testing this method...", Scope = "member", Target = "~M:Mocale.UnitTests.Cache.InMemoryCacheManagerTests.ClearCache_CallsClearMethod")]

--- a/tests/Mocale.UnitTests/Properties/GlobalUsings.cs
+++ b/tests/Mocale.UnitTests/Properties/GlobalUsings.cs
@@ -1,3 +1,4 @@
 global using Xunit;
 global using FluentAssertions;
 global using Moq;
+global using Mocale.UnitTests.TestHelpers;

--- a/tests/Mocale.UnitTests/TestHelpers/ServiceCollectionAssertions.cs
+++ b/tests/Mocale.UnitTests/TestHelpers/ServiceCollectionAssertions.cs
@@ -1,0 +1,41 @@
+namespace Mocale.UnitTests.TestHelpers;
+
+public static class ServiceCollectionAssertions
+{
+    /// <summary>
+    /// Asserts that a given service type is registered in the service collection.
+    /// </summary>
+    public static void ShouldContainService<TService>(this IServiceCollection services)
+    {
+        var service = services.FirstOrDefault(s => s.ServiceType == typeof(TService));
+        Assert.NotNull(service);
+    }
+
+    /// <summary>
+    /// Asserts that a given service type is NOT registered in the service collection.
+    /// </summary>
+    public static void ShouldNotContainService<TService>(this IServiceCollection services)
+    {
+        var service = services.FirstOrDefault(s => s.ServiceType == typeof(TService));
+        Assert.Null(service);
+    }
+
+    /// <summary>
+    /// Asserts that a specific implementation type is registered in the service collection.
+    /// </summary>
+    public static void ShouldContainImplementation<TService, TImplementation>(this IServiceCollection services)
+    {
+        var service = services.FirstOrDefault(s => s.ImplementationType == typeof(TImplementation));
+        Assert.NotNull(service);
+    }
+
+    /// <summary>
+    /// Asserts that a specific implementation type is NOT registered in the service collection.
+    /// </summary>
+    public static void ShouldNotContainImplementation<TService, TImplementation>(this IServiceCollection services)
+    {
+        var service = services.FirstOrDefault(s => s.ImplementationType == typeof(TImplementation));
+        Assert.Null(service);
+    }
+}
+


### PR DESCRIPTION
Currently Mocale HAS to be used with the SQLite cache provider unless you roll your own caching solution. I've finally implemented a very basic in memory cache system so when external localizations are fetched they'll stick in memory for the lifetime of the application.

This has the downside of everytime you run the app it needs to call out to refresh the localizations however it means people using local cache only can have mocale run without the need to persist any data!

This PR also kicks the ball off for testing the app builder elements, I will do more in a seperate PR for the various config points in the library!