### PR TITLE
Fixed warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -142,6 +142,13 @@ csharp_style_prefer_null_check_over_type_check = true:warning
 dotnet_style_namespace_match_folder = true:suggestion
 dotnet_diagnostic.IDE0130.severity = suggestion
 
+# Rule IDE0040: Add accessibility modifiers
+# https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0040
+# https://github.com/dotnet/msbuild/issues/11426#issuecomment-2662244499
+dotnet_diagnostic.IDE0040.severity = none
+# options
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+
 # C# Style Rules
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#c-style-rules
 [*.{cs,csx,cake}]

--- a/src/Mocale/Abstractions/ICacheUpdateManager.cs
+++ b/src/Mocale/Abstractions/ICacheUpdateManager.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 namespace Mocale.Abstractions;
 

--- a/src/Mocale/Extensions/BindableObjectExtension.cs
+++ b/src/Mocale/Extensions/BindableObjectExtension.cs
@@ -1,5 +1,3 @@
-using Mocale.Managers;
-
 namespace Mocale.Extensions;
 
 /// <summary>

--- a/src/Mocale/Extensions/LocalizeExtensionBase.cs
+++ b/src/Mocale/Extensions/LocalizeExtensionBase.cs
@@ -3,10 +3,16 @@ using Ardalis.GuardClauses;
 
 namespace Mocale.Extensions;
 
+/// <summary>
+/// Localize Extension Base
+/// </summary>
+/// <param name="translatorManager">The translator manager instance to bind to</param>
 public abstract class LocalizeExtensionBase(ITranslatorManager translatorManager)
 {
     // ReSharper disable once InconsistentNaming
+#pragma warning disable IDE1006 // Naming Styles
     internal readonly ITranslatorManager translatorManager = Guard.Against.Null(translatorManager, nameof(translatorManager));
+#pragma warning restore IDE1006 // Naming Styles
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     internal ITranslatorManager GetTranslatorManager()
@@ -25,12 +31,17 @@ public abstract class LocalizeBindingExtensionBase(ITranslatorManager translator
     /// <inheritdoc />
     public abstract Binding ProvideValue(IServiceProvider serviceProvider);
 
+    /// <inheritdoc />
     object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider)
     {
         return ProvideValue(serviceProvider);
     }
 }
 
+/// <summary>
+/// Base class for localize extensions that use MultiBindings
+/// </summary>
+/// <param name="translatorManager"></param>
 public abstract class LocalizeMultiBindingExtensionBase(ITranslatorManager translatorManager)
     : LocalizeExtensionBase(translatorManager), IMarkupExtension<MultiBinding>
 {

--- a/src/Mocale/Managers/TranslatorManager.cs
+++ b/src/Mocale/Managers/TranslatorManager.cs
@@ -106,6 +106,7 @@ internal partial class TranslatorManager : IInternalTranslatorManager
 
         switch (source)
         {
+            default:
             case TranslationSource.External:
             case TranslationSource.WarmCache:
             case TranslationSource.ColdCache:

--- a/tests/Mocale.UnitTests/Managers/TranslationResolverTests.cs
+++ b/tests/Mocale.UnitTests/Managers/TranslationResolverTests.cs
@@ -119,7 +119,8 @@ public class TranslationResolverTests : FixtureBase<ITranslationResolver>
         externalLocalizationProvider.Setup(m => m.GetValuesForCultureAsync(It.IsAny<CultureInfo>()))
             .ReturnsAsync(new ExternalLocalizationResult
             {
-                Success = true, Localizations = new Dictionary<string, string> { { "Hello", "Hola" } }
+                Success = true,
+                Localizations = new Dictionary<string, string> { { "Hello", "Hola" } }
             });
 
         localisationCacheManager.Setup(m =>
@@ -191,7 +192,8 @@ public class TranslationResolverTests : FixtureBase<ITranslationResolver>
         externalLocalizationProvider.Setup(m => m.GetValuesForCultureAsync(It.IsAny<CultureInfo>()))
             .ReturnsAsync(new ExternalLocalizationResult
             {
-                Success = true, Localizations = new Dictionary<string, string> { { "Hello", "Hola" } }
+                Success = true,
+                Localizations = new Dictionary<string, string> { { "Hello", "Hola" } }
             });
 
         localisationCacheManager.Setup(m =>
@@ -234,7 +236,8 @@ public class TranslationResolverTests : FixtureBase<ITranslationResolver>
         externalLocalizationProvider.Setup(m => m.GetValuesForCultureAsync(It.IsAny<CultureInfo>()))
             .ReturnsAsync(new ExternalLocalizationResult
             {
-                Success = true, Localizations = new Dictionary<string, string> { { "Hello", "Hola" } }
+                Success = true,
+                Localizations = new Dictionary<string, string> { { "Hello", "Hola" } }
             });
 
         localisationCacheManager.Setup(m =>
@@ -519,7 +522,10 @@ public class TranslationResolverTests : FixtureBase<ITranslationResolver>
 
         logger.VerifyLog(log => log.LogInformation(
             "The following keys were present in the local translations but not in the cache: {AddedKeys}",
-            new List<string>() { "City","WelcomeToMyShop" }),
+            new List<string>()
+            {
+                "City","WelcomeToMyShop"
+            }),
             Times.Once);
     }
 


### PR DESCRIPTION
There were alot of warnings in the project and the vast majority were caused by an analuyzer change after updating to `9.0.200`. [This](https://github.com/dotnet/msbuild/issues/11426) issue was causing a huge amount of warning noise and I used [this](https://github.com/dotnet/msbuild/issues/11426#issuecomment-2662244499) fix in the `.editorconfig` to hide those warnings.

All other warnings have now been address  since I've been able to actually see them through the forest of interface visibility warnings!