### PR TITLE
Fix Duplicate Embedded Resources

### DIFF
--- a/src/Mocale.SourceGenerators/build/Package.targets
+++ b/src/Mocale.SourceGenerators/build/Package.targets
@@ -1,6 +1,5 @@
 <Project>
   <ItemGroup>
-    <EmbeddedResource Include="$(MocaleResourcePath)" />
     <AdditionalFiles Include="$(MocaleResourcePath)" />
   </ItemGroup>
 </Project>

--- a/src/Mocale/build/Package.targets
+++ b/src/Mocale/build/Package.targets
@@ -1,7 +1,6 @@
 <Project>
   <ItemGroup>
     <EmbeddedResource Include="$(MocaleResourcePath)" />
-    <AdditionalFiles Include="$(MocaleResourcePath)" />
   </ItemGroup>
 </Project>
 


### PR DESCRIPTION
This fixes the following error when using Mocale with Source generated keys!

```
Microsoft.NET.Sdk.DefaultItems.Shared.targets(201, 5): [NETSDK1022] Duplicate 'EmbeddedResource' items were included. 
The .NET SDK includes 'EmbeddedResource' items from your project directory by default. 
You can either remove these items from your project file, or set the 'EnableDefaultEmbeddedResourceItems' property to 'false' if you want to explicitly include them in your project file. For more information, see https://aka.ms/sdkimplicititems. 
The duplicate items were: 'Resources\Locales\en-GB.json'
```

Both projects had the same targets, now Mocale will only add `EmbeddedResource` and Mocale.SourceGenerators will only add `AdditionalFiles`