### PR TITLE
Add more translation options for enums

### DIFF
--- a/src/Mocale/Abstractions/ITranslatorManager.cs
+++ b/src/Mocale/Abstractions/ITranslatorManager.cs
@@ -17,7 +17,7 @@ public interface ITranslatorManager : INotifyPropertyChanged
     /// </summary>
     /// <param name="key">Key to translate</param>
     /// <returns>Translation result</returns>
-    string? Translate(string key);
+    string Translate(string key);
 
     /// <summary>
     /// Translate
@@ -25,5 +25,5 @@ public interface ITranslatorManager : INotifyPropertyChanged
     /// <param name="key">Key to translate</param>
     /// <param name="parameters">Parameters to translate</param>
     /// <returns>Translation result</returns>
-    string? Translate(string key, object[] parameters);
+    string Translate(string key, object[] parameters);
 }

--- a/src/Mocale/Extensions/BindableObjectExtension.cs
+++ b/src/Mocale/Extensions/BindableObjectExtension.cs
@@ -84,6 +84,27 @@ public static class BindableObjectExtension
     }
 
     /// <summary>
+    /// Set Enum Value Translation
+    /// </summary>
+    /// <param name="bindableObject">The bindable object to apply a translation</param>
+    /// <param name="property">The bindable property to target for translation</param>
+    /// <param name="enumValue">The enum value to localize</param>
+    /// <param name="stringFormat">The string format to apply to the binding</param>
+    public static void SetEnumValueTranslation(this BindableObject bindableObject, BindableProperty property, Enum enumValue, string stringFormat = "{0}")
+    {
+        ArgumentNullException.ThrowIfNull(bindableObject, nameof(bindableObject));
+
+        var extension = new LocalizeEnumExtension()
+        {
+            Source = enumValue,
+            Mode = BindingMode.OneWay,
+            StringFormat = stringFormat,
+        };
+
+        bindableObject.SetBinding(property, extension.ProvideValue(EmptyServiceProvider.Instance));
+    }
+
+    /// <summary>
     /// Set Translation With Multiple Bindings
     /// </summary>
     /// <param name="bindableObject">The bindable object to apply a translation</param>
@@ -158,6 +179,21 @@ public static class BindableObjectExtension
         where TView : View
     {
         SetEnumTranslation(view as BindableObject, property, source, stringFormat);
+        return view;
+    }
+
+    /// <summary>
+    /// Set Enum Value Translation
+    /// </summary>
+    /// <typeparam name="TView">The type of the view having the translation applied</typeparam>
+    /// <param name="view">The view to apply a translation</param>
+    /// <param name="property">The bindable property to target for translation</param>
+    /// <param name="enumValue">The enum value to localize</param>
+    /// <param name="stringFormat">The string format to apply to the binding</param>
+    public static TView SetEnumValueTranslation<TView>(this TView view, BindableProperty property, Enum enumValue, string stringFormat = "{0}")
+        where TView : View
+    {
+        SetEnumValueTranslation(view as BindableObject, property, enumValue, stringFormat);
         return view;
     }
 

--- a/src/Mocale/Extensions/LocalizeEnumBehaviorExtension.cs
+++ b/src/Mocale/Extensions/LocalizeEnumBehaviorExtension.cs
@@ -1,0 +1,11 @@
+namespace Mocale.Extensions;
+
+internal static class LocalizeEnumBehaviorExtension
+{
+    public static bool ShouldLocalizeEnum(this LocalizeEnumBehavior localizeEnumBehavior, Enum enumValue)
+    {
+        return localizeEnumBehavior.OverrideRules.TryGetValue(enumValue.GetType(), out var rule)
+            ? rule.UseAttribute
+            : localizeEnumBehavior.UseAttribute;
+    }
+}

--- a/src/Mocale/Extensions/TranslatorManagerExtensions.cs
+++ b/src/Mocale/Extensions/TranslatorManagerExtensions.cs
@@ -29,6 +29,11 @@ public static class TranslatorManagerExtensions
     /// <returns></returns>
     public static string TranslateEnum(this ITranslatorManager translatorManager, Enum enumValue, LocalizeEnumBehavior localizeEnumBehavior)
     {
+        if (!localizeEnumBehavior.ShouldLocalizeEnum(enumValue))
+        {
+            return enumValue.ToString();
+        }
+
         var translationKey = EnumTranslationKeyHelper.GetTranslationKey(enumValue, localizeEnumBehavior);
 
         return translatorManager.Translate(translationKey);

--- a/src/Mocale/Extensions/TranslatorManagerExtensions.cs
+++ b/src/Mocale/Extensions/TranslatorManagerExtensions.cs
@@ -1,0 +1,36 @@
+using Mocale.Helper;
+
+namespace Mocale.Extensions;
+
+/// <summary>
+/// Translator Manager Extensions
+/// </summary>
+public static class TranslatorManagerExtensions
+{
+    /// <summary>
+    /// Translate Enum
+    /// </summary>
+    /// <param name="translatorManager">The translator manager instance</param>
+    /// <param name="enumValue">The enum value to translate</param>
+    /// <returns>Translation result</returns>
+    public static string TranslateEnum(this ITranslatorManager translatorManager, Enum enumValue)
+    {
+        var mocaleConfiguration = MocaleLocator.MocaleConfiguration;
+
+        return TranslateEnum(translatorManager, enumValue, mocaleConfiguration.EnumBehavior);
+    }
+
+    /// <summary>
+    /// Translate Enum
+    /// </summary>
+    /// <param name="translatorManager">The translator manager instance</param>
+    /// <param name="enumValue">The enum value to translate</param>
+    /// <param name="localizeEnumBehavior">The localization behavior to use for the enum</param>
+    /// <returns></returns>
+    public static string TranslateEnum(this ITranslatorManager translatorManager, Enum enumValue, LocalizeEnumBehavior localizeEnumBehavior)
+    {
+        var translationKey = EnumTranslationKeyHelper.GetTranslationKey(enumValue, localizeEnumBehavior);
+
+        return translatorManager.Translate(translationKey);
+    }
+}

--- a/src/Mocale/Extensions/TranslatorManagerExtensions.cs
+++ b/src/Mocale/Extensions/TranslatorManagerExtensions.cs
@@ -27,7 +27,7 @@ public static class TranslatorManagerExtensions
     /// <param name="enumValue">The enum value to translate</param>
     /// <param name="localizeEnumBehavior">The localization behavior to use for the enum</param>
     /// <returns></returns>
-    public static string TranslateEnum(this ITranslatorManager translatorManager, Enum enumValue, LocalizeEnumBehavior localizeEnumBehavior)
+    internal static string TranslateEnum(this ITranslatorManager translatorManager, Enum enumValue, LocalizeEnumBehavior localizeEnumBehavior)
     {
         if (!localizeEnumBehavior.ShouldLocalizeEnum(enumValue))
         {

--- a/src/Mocale/Helper/EnumTranslationKeyHelper.cs
+++ b/src/Mocale/Helper/EnumTranslationKeyHelper.cs
@@ -1,32 +1,19 @@
 namespace Mocale.Helper;
 
-internal class EnumTranslationKeyHelper(IMocaleConfiguration mocaleConfiguration)
+internal static class EnumTranslationKeyHelper
 {
-    public string GetTranslationKey(Enum @enum)
+    public static string GetTranslationKey(Enum @enum, LocalizeEnumBehavior behavior)
     {
-        string? translationKey = null;
-
-        var behavior = mocaleConfiguration.EnumBehavior;
-
-        if (behavior.OverrideRules.TryGetValue(@enum.GetType(), out var rule))
-        {
-            translationKey = GetKey(@enum, rule.UseAttribute, rule.LocalizeAttribute, rule.AttributePropertyName);
-        }
-        else
-        {
-            translationKey = GetKey(@enum, behavior.UseAttribute, behavior.LocalizeAttribute, behavior.AttributePropertyName);
-        }
-
-        translationKey ??= @enum.ToString();
-
-        return translationKey;
+        return behavior.OverrideRules.TryGetValue(@enum.GetType(), out var rule)
+            ? GetKey(@enum, rule.UseAttribute, rule.LocalizeAttribute, rule.AttributePropertyName)
+            : GetKey(@enum, behavior.UseAttribute, behavior.LocalizeAttribute, behavior.AttributePropertyName);
     }
 
-    private static string? GetKey(Enum enumValue, bool useAttribute, Type localizeAttribute, string propertyName)
+    private static string GetKey(Enum enumValue, bool useAttribute, Type localizeAttribute, string propertyName)
     {
         if (useAttribute)
         {
-            return enumValue.GetAttributeValue(localizeAttribute, propertyName);
+            return enumValue.GetAttributeValue(localizeAttribute, propertyName) ?? enumValue.ToString();
         }
         else
         {

--- a/src/Mocale/Managers/TranslationResolver.cs
+++ b/src/Mocale/Managers/TranslationResolver.cs
@@ -35,9 +35,8 @@ internal class TranslationResolver(
                 {
                     Loaded = true,
                     Source = TranslationSource.WarmCache,
-                    Localization = new Localization()
+                    Localization = new Localization(cultureInfo)
                     {
-                        CultureInfo = cultureInfo,
                         Translations = cacheTranslations,
                     },
                 };
@@ -71,9 +70,8 @@ internal class TranslationResolver(
         {
             Loaded = true,
             Source = TranslationSource.External,
-            Localization = new Localization()
+            Localization = new Localization(cultureInfo)
             {
-                CultureInfo = cultureInfo,
                 Translations = externalResult.Localizations,
             },
         };
@@ -115,9 +113,8 @@ internal class TranslationResolver(
             {
                 Loaded = true,
                 Source = TranslationSource.Internal,
-                Localization = new Localization()
+                Localization = new Localization(cultureInfo)
                 {
-                    CultureInfo = cultureInfo,
                     Translations = internalTranslations,
                 },
             };
@@ -131,9 +128,8 @@ internal class TranslationResolver(
                 Source = cacheUpdateManager.CanUpdateCache(cultureInfo)
                     ? TranslationSource.ColdCache
                     : TranslationSource.WarmCache,
-                Localization = new Localization()
+                Localization = new Localization(cultureInfo)
                 {
-                    CultureInfo = cultureInfo,
                     Translations = cachedTranslations,
                 },
             };
@@ -175,9 +171,8 @@ internal class TranslationResolver(
         {
             Loaded = true,
             Source = cacheTemperature,
-            Localization = new Localization()
+            Localization = new Localization(cultureInfo)
             {
-                CultureInfo = cultureInfo,
                 Translations = cachedTranslations,
             },
         };

--- a/src/Mocale/Managers/TranslatorManager.cs
+++ b/src/Mocale/Managers/TranslatorManager.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Globalization;
 using Ardalis.GuardClauses;
+
 namespace Mocale.Managers;
 
 /// <inheritdoc />
@@ -39,7 +40,7 @@ internal partial class TranslatorManager : IInternalTranslatorManager
 
     #region Methods
 
-    public object? this[string resourceKey] => Translate(resourceKey);
+    public object this[string resourceKey] => Translate(resourceKey);
 
     #endregion Methods
 
@@ -47,7 +48,7 @@ internal partial class TranslatorManager : IInternalTranslatorManager
 
     #region - ITranslatorManager
 
-    public string? Translate(string key)
+    public string Translate(string key)
     {
         if (PreferredLocalizations.TryGetValue(key, out var externalTranslation))
         {
@@ -70,7 +71,7 @@ internal partial class TranslatorManager : IInternalTranslatorManager
         return mocaleConfiguration.NotFoundSymbol + key + StringExtension.Reverse(mocaleConfiguration.NotFoundSymbol);
     }
 
-    public string? Translate(string key, object[] parameters)
+    public string Translate(string key, object[] parameters)
     {
         var translation = Translate(key);
 

--- a/src/Mocale/Models/Localization.cs
+++ b/src/Mocale/Models/Localization.cs
@@ -4,12 +4,12 @@ namespace Mocale.Models;
 /// <summary>
 /// Localization
 /// </summary>
-public class Localization
+public class Localization(CultureInfo cultureInfo)
 {
     /// <summary>
     /// Corresponding culture
     /// </summary>
-    public required CultureInfo CultureInfo { get; set; }
+    public CultureInfo CultureInfo { get; } = cultureInfo;
 
     /// <summary>
     /// Translations
@@ -19,8 +19,5 @@ public class Localization
     /// <summary>
     /// Blank localization
     /// </summary>
-    public static Localization Invariant => new()
-    {
-        CultureInfo = new CultureInfo(""),
-    };
+    public static Localization Invariant => new(CultureInfo.InvariantCulture);
 }

--- a/tests/Mocale.UnitTests/Extensions/BindableObjectExtensionTests.cs
+++ b/tests/Mocale.UnitTests/Extensions/BindableObjectExtensionTests.cs
@@ -26,6 +26,10 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
 
     #region Tests
 
+    #region - SetTranslation
+
+    #region -- Void
+
     [Fact]
     public void SetTranslationVoid_WhenBindableObjectIsNull_ShouldThrow()
     {
@@ -79,7 +83,7 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         var label = new Label();
 
         // Act
-        ((BindableObject)label).SetTranslation(Label.TextProperty, "ApplicationTitle", null);
+        ((BindableObject)label).SetTranslation(Label.TextProperty, "ApplicationTitle");
 
         // Assert
         Assert.Equal("Mocale!", label.Text);
@@ -100,7 +104,7 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         translatorManager.UpdateTranslations(enGbLocalization, TranslationSource.Internal);
 
         var label = new Label();
-        ((BindableObject)label).SetTranslation(Label.TextProperty, "HelloWorld", null);
+        ((BindableObject)label).SetTranslation(Label.TextProperty, "HelloWorld");
         Assert.Equal("Hello World!", label.Text);
 
         // Act
@@ -140,6 +144,10 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         // Assert
         Assert.Equal("MOCALE!", label.Text);
     }
+
+    #endregion -- Void
+
+    #region -- View
 
     [Fact]
     public void SetTranslationView_WhenViewIsNull_ShouldThrow()
@@ -228,6 +236,14 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         Assert.IsType<Label>(view);
         Assert.Equal(label, view);
     }
+
+    #endregion -- View
+
+    #endregion - SetTranslation
+
+    #region - SetTranslationBinding
+
+    #region -- Void
 
     [Fact]
     public void SetTranslationBindingVoid_WhenBindableObjectIsNull_ShouldThrow()
@@ -471,6 +487,10 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
 
         Assert.Equal("La température est 21.3 \u00b0C", label.Text);
     }
+
+    #endregion -- Void
+
+    #region -- View
 
     [Fact]
     public void SetTranslationBindingView_WhenBindableObjectIsNull_ShouldThrow()
@@ -722,6 +742,14 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         Assert.Equal("La température est 21.3 \u00b0C", label.Text);
     }
 
+    #endregion -- View
+
+    #endregion - SetTranslationBinding
+
+    #region - SetEnumTranslation
+
+    #region -- Void
+
     [Fact]
     public void SetEnumTranslationVoid_WhenBindableObjectIsNull_ShouldThrow()
     {
@@ -743,9 +771,10 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
     {
         // Arrange
         BindableObject bindableObject = new Label();
+        Binding binding = null!;
 
         // Act
-        var ex = Assert.Throws<ArgumentNullException>(() => bindableObject.SetEnumTranslation(Label.TextProperty, null!));
+        var ex = Assert.Throws<ArgumentNullException>(() => bindableObject.SetEnumTranslation(Label.TextProperty, binding));
 
         // Assert
         Assert.Equal("Value cannot be null. (Parameter 'source')", ex.Message);
@@ -1015,6 +1044,10 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         // Assert
         Assert.Equal("Banane", label.Text);
     }
+
+    #endregion -- Void
+
+    #region -- View
 
     [Fact]
     public void SetEnumTranslationView_WhenBindableObjectIsNull_ShouldThrow()
@@ -1316,6 +1349,411 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         Assert.Equal("Banane", label.Text);
     }
 
+    #endregion -- View
+
+    #endregion - SetEnumTranslation
+
+    #region - SetEnumValueTranslation
+
+    #region -- Void
+
+    [Fact]
+    public void SetEnumValueTranslationVoid_WhenConfiguredNotToUseAttribute_ShouldEnumString()
+    {
+        // Arrange
+        MocaleLocator.MocaleConfiguration = new MocaleConfiguration()
+        {
+            EnumBehavior = new LocalizeEnumBehavior()
+            {
+                UseAttribute = false,
+            }
+        };
+
+        BindableObject bindableObject = new Label();
+
+        // Act
+        bindableObject.SetEnumValueTranslation(Label.TextProperty, Fruit.Apple);
+
+        // Assert
+        var label = Assert.IsType<Label>(bindableObject);
+        Assert.Equal("Apple", label.Text);
+    }
+
+    [Fact]
+    public void SetEnumValueTranslationVoid_WhenTranslationKeyDoesNotExist_ShouldSetNotFoundKey()
+    {
+        // Arrange
+        MocaleLocator.MocaleConfiguration = new MocaleConfiguration()
+        {
+            EnumBehavior = new LocalizeEnumBehavior()
+            {
+                UseAttribute = true,
+                AttributePropertyName = nameof(DescriptionAttribute.Description),
+                LocalizeAttribute = typeof(DescriptionAttribute),
+            }
+        };
+
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "MapplicationTitle", "Mocale!" },
+            }
+        };
+
+        translatorManager.UpdateTranslations(enGbLocalization, TranslationSource.Internal);
+
+        BindableObject bindableObject = new Label();
+
+        // Act
+        bindableObject.SetEnumValueTranslation(Label.TextProperty, Fruit.Apple);
+
+        // Assert
+        var label = Assert.IsType<Label>(bindableObject);
+        Assert.Equal("$Fruit_Apple$", label.Text);
+    }
+
+    [Fact]
+    public void SetEnumValueTranslationVoid_WhenTranslationKeyExists_ShouldFormatTranslation()
+    {
+        // Arrange
+        MocaleLocator.MocaleConfiguration = new MocaleConfiguration()
+        {
+            EnumBehavior = new LocalizeEnumBehavior()
+            {
+                UseAttribute = true,
+                AttributePropertyName = nameof(DescriptionAttribute.Description),
+                LocalizeAttribute = typeof(DescriptionAttribute),
+            }
+        };
+
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "Fruit_Apple", "Apple" },
+                { "Fruit_Banana", "Banana" },
+                { "Fruit_Cherry", "Cherry" },
+            }
+        };
+
+        translatorManager.UpdateTranslations(enGbLocalization, TranslationSource.Internal);
+
+        BindableObject bindableObject = new Label();
+
+        // Act
+        bindableObject.SetEnumValueTranslation(Label.TextProperty, Fruit.Banana);
+
+        // Assert
+        var label = Assert.IsType<Label>(bindableObject);
+        Assert.Equal("Banana", label.Text);
+    }
+
+    [Fact]
+    public void SetEnumValueTranslationVoid_WhenTranslationKeyExistsForCultureOneButNotCultureTwo_ShouldFormatTranslationCorrectly()
+    {
+        // Arrange
+        MocaleLocator.MocaleConfiguration = new MocaleConfiguration()
+        {
+            EnumBehavior = new LocalizeEnumBehavior()
+            {
+                UseAttribute = true,
+                AttributePropertyName = nameof(DescriptionAttribute.Description),
+                LocalizeAttribute = typeof(DescriptionAttribute),
+            }
+        };
+
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "Fruit_Apple", "Apple" },
+                { "Fruit_Banana", "Banana" },
+                { "Fruit_Cherry", "Cherry" },
+            }
+        };
+
+        var frFrLocalization = new Localization(new CultureInfo("fr-FR"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "NotFruit", "Ce n'est pas un fruit" },
+            }
+        };
+
+        translatorManager.UpdateTranslations(enGbLocalization, TranslationSource.Internal);
+
+        BindableObject bindableObject = new Label();
+
+        bindableObject.SetEnumValueTranslation(Label.TextProperty, Fruit.Banana);
+
+        var label = Assert.IsType<Label>(bindableObject);
+        Assert.Equal("Banana", label.Text);
+
+        // Act
+        translatorManager.UpdateTranslations(frFrLocalization, TranslationSource.Internal);
+
+        // Assert
+        Assert.Equal("$Fruit_Banana$", label.Text);
+    }
+
+    [Fact]
+    public void SetEnumValueTranslationVoid_WhenTranslationKeyExistsForAllCultures_ShouldUpdateTranslationCorrectly()
+    {
+        // Arrange
+        MocaleLocator.MocaleConfiguration = new MocaleConfiguration()
+        {
+            EnumBehavior = new LocalizeEnumBehavior()
+            {
+                UseAttribute = true,
+                AttributePropertyName = nameof(DescriptionAttribute.Description),
+                LocalizeAttribute = typeof(DescriptionAttribute),
+            }
+        };
+
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "Fruit_Apple", "Apple" },
+                { "Fruit_Banana", "Banana" },
+                { "Fruit_Cherry", "Cherry" },
+            }
+        };
+
+        var frFrLocalization = new Localization(new CultureInfo("fr-FR"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "Fruit_Apple", "Pomme" },
+                { "Fruit_Banana", "Banane" },
+                { "Fruit_Cherry", "Cerise" },
+            }
+        };
+
+        translatorManager.UpdateTranslations(enGbLocalization, TranslationSource.Internal);
+
+        BindableObject bindableObject = new Label();
+
+        bindableObject.SetEnumValueTranslation(Label.TextProperty, Fruit.Banana);
+
+        var label = Assert.IsType<Label>(bindableObject);
+        Assert.Equal("Banana", label.Text);
+
+        // Act
+        translatorManager.UpdateTranslations(frFrLocalization, TranslationSource.Internal);
+
+        // Assert
+        Assert.Equal("Banane", label.Text);
+    }
+
+    #endregion -- Void
+
+    #region -- View
+
+    [Fact]
+    public void SetEnumValueTranslationView_WhenConfiguredNotToUseAttribute_ShouldEnumString()
+    {
+        // Arrange
+        MocaleLocator.MocaleConfiguration = new MocaleConfiguration()
+        {
+            EnumBehavior = new LocalizeEnumBehavior()
+            {
+                UseAttribute = false,
+            }
+        };
+
+        var label = new Label();
+
+        // Act
+        var view = label.SetEnumValueTranslation(Label.TextProperty, Fruit.Apple);
+
+        // Assert
+        Assert.IsType<Label>(view);
+        Assert.Equal(label, view);
+        Assert.Equal("Apple", label.Text);
+    }
+
+    [Fact]
+    public void SetEnumValueTranslationView_WhenTranslationKeyDoesNotExist_ShouldSetNotFoundKey()
+    {
+        // Arrange
+        MocaleLocator.MocaleConfiguration = new MocaleConfiguration()
+        {
+            EnumBehavior = new LocalizeEnumBehavior()
+            {
+                UseAttribute = true,
+                AttributePropertyName = nameof(DescriptionAttribute.Description),
+                LocalizeAttribute = typeof(DescriptionAttribute),
+            }
+        };
+
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "MapplicationTitle", "Mocale!" },
+            }
+        };
+
+        translatorManager.UpdateTranslations(enGbLocalization, TranslationSource.Internal);
+
+        var label = new Label();
+
+        // Act
+        var view = label.SetEnumValueTranslation(Label.TextProperty, Fruit.Apple);
+
+        // Assert
+        Assert.IsType<Label>(view);
+        Assert.Equal(label, view);
+        Assert.Equal("$Fruit_Apple$", label.Text);
+    }
+
+    [Fact]
+    public void SetEnumValueTranslationView_WhenTranslationKeyExists_ShouldFormatTranslation()
+    {
+        // Arrange
+        MocaleLocator.MocaleConfiguration = new MocaleConfiguration()
+        {
+            EnumBehavior = new LocalizeEnumBehavior()
+            {
+                UseAttribute = true,
+                AttributePropertyName = nameof(DescriptionAttribute.Description),
+                LocalizeAttribute = typeof(DescriptionAttribute),
+            }
+        };
+
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "Fruit_Apple", "Apple" },
+                { "Fruit_Banana", "Banana" },
+                { "Fruit_Cherry", "Cherry" },
+            }
+        };
+
+        translatorManager.UpdateTranslations(enGbLocalization, TranslationSource.Internal);
+
+        var label = new Label();
+
+        // Act
+        var view = label.SetEnumValueTranslation(Label.TextProperty, Fruit.Banana);
+
+        // Assert
+        Assert.IsType<Label>(view);
+        Assert.Equal(label, view);
+        Assert.Equal("Banana", label.Text);
+    }
+
+    [Fact]
+    public void SetEnumValueTranslationView_WhenTranslationKeyExistsForCultureOneButNotCultureTwo_ShouldFormatTranslationCorrectly()
+    {
+        // Arrange
+        MocaleLocator.MocaleConfiguration = new MocaleConfiguration()
+        {
+            EnumBehavior = new LocalizeEnumBehavior()
+            {
+                UseAttribute = true,
+                AttributePropertyName = nameof(DescriptionAttribute.Description),
+                LocalizeAttribute = typeof(DescriptionAttribute),
+            }
+        };
+
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "Fruit_Apple", "Apple" },
+                { "Fruit_Banana", "Banana" },
+                { "Fruit_Cherry", "Cherry" },
+            }
+        };
+
+        var frFrLocalization = new Localization(new CultureInfo("fr-FR"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "NotFruit", "Ce n'est pas un fruit" },
+            }
+        };
+
+        translatorManager.UpdateTranslations(enGbLocalization, TranslationSource.Internal);
+
+        var label = new Label();
+
+        var view = label.SetEnumValueTranslation(Label.TextProperty, Fruit.Banana);
+
+        Assert.IsType<Label>(view);
+        Assert.Equal(label, view);
+        Assert.Equal("Banana", label.Text);
+
+        // Act
+        translatorManager.UpdateTranslations(frFrLocalization, TranslationSource.Internal);
+
+        // Assert
+        Assert.Equal("$Fruit_Banana$", label.Text);
+    }
+
+    [Fact]
+    public void SetEnumValueTranslationView_WhenTranslationKeyExistsForAllCultures_ShouldUpdateTranslationCorrectly()
+    {
+        // Arrange
+        MocaleLocator.MocaleConfiguration = new MocaleConfiguration()
+        {
+            EnumBehavior = new LocalizeEnumBehavior()
+            {
+                UseAttribute = true,
+                AttributePropertyName = nameof(DescriptionAttribute.Description),
+                LocalizeAttribute = typeof(DescriptionAttribute),
+            }
+        };
+
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "Fruit_Apple", "Apple" },
+                { "Fruit_Banana", "Banana" },
+                { "Fruit_Cherry", "Cherry" },
+            }
+        };
+
+        var frFrLocalization = new Localization(new CultureInfo("fr-FR"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "Fruit_Apple", "Pomme" },
+                { "Fruit_Banana", "Banane" },
+                { "Fruit_Cherry", "Cerise" },
+            }
+        };
+
+        translatorManager.UpdateTranslations(enGbLocalization, TranslationSource.Internal);
+
+        var label = new Label();
+
+        var view = label.SetEnumValueTranslation(Label.TextProperty, Fruit.Banana);
+
+        Assert.IsType<Label>(view);
+        Assert.Equal(label, view);
+        Assert.Equal("Banana", label.Text);
+
+        // Act
+        translatorManager.UpdateTranslations(frFrLocalization, TranslationSource.Internal);
+
+        // Assert
+        Assert.Equal("Banane", label.Text);
+    }
+
+    #endregion -- View
+
+    #endregion - SetEnumValueTranslation
+
+    #region - SetTranslationMultiBinding
+
+    #region -- Void
+
     [Fact]
     public void SetTranslationMultiBindingVoid_WhenBindableObjectIsNull_ShouldThrow()
     {
@@ -1495,6 +1933,10 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         // Assert
         Assert.Equal("Jimmy aime les Cherry quand il est 19.2 dehors", label.Text);
     }
+
+    #endregion -- Void
+
+    #region -- View
 
     [Fact]
     public void SetTranslationMultiBindingView_WhenTranslationKeyDoesNotExist_ShouldSetNotFoundKey()
@@ -1676,6 +2118,10 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         Assert.Equal("Required input Bindings was empty. (Parameter 'Bindings')", ex.Message);
     }
 
+    #endregion -- View
+
+    #endregion - SetTranslationMultiBinding
+
     #endregion Tests
 
     #region Test Data
@@ -1689,7 +2135,7 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
                 : null;
         }
 
-        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
             throw new NotImplementedException();
         }
@@ -1701,7 +2147,7 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         public partial double Temperature { get; set; }
 
         [ObservableProperty]
-        public partial string Name { get; set; }
+        public partial string Name { get; set; } = string.Empty;
 
         [ObservableProperty]
         public partial Fruit? SelectedFruit { get; set; }

--- a/tests/Mocale.UnitTests/Extensions/BindableObjectExtensionTests.cs
+++ b/tests/Mocale.UnitTests/Extensions/BindableObjectExtensionTests.cs
@@ -43,9 +43,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
     public void SetTranslationVoid_WhenTranslationKeyDoesNotExist_ShouldSetNotFoundKey()
     {
         // Arrange
-        var localization = new Localization()
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "MapplicationTitle", "Mocale!"}
@@ -67,9 +66,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
     public void SetTranslationVoid_WhenTranslationKeyExists_ShouldSetTranslation()
     {
         // Arrange
-        var localization = new Localization()
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "ApplicationTitle", "Mocale!"}
@@ -91,9 +89,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
     public void SetTranslationVoid_WhenLocaleChanges_ShouldUpdateTranslation()
     {
         // Arrange
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "HelloWorld", "Hello World!"}
@@ -107,9 +104,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         Assert.Equal("Hello World!", label.Text);
 
         // Act
-        var frFrLocalization = new Localization()
+        var frFrLocalization = new Localization(new CultureInfo("fr-FR"))
         {
-            CultureInfo = new CultureInfo("fr-FR"),
             Translations = new Dictionary<string, string>()
             {
                 { "HelloWorld", "Bonjour le monde!!"}
@@ -126,9 +122,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
     public void SetTranslationVoid_WhenUsingConverter_ShouldTranslateAndUseConverter()
     {
         // Arrange
-        var localization = new Localization()
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "ApplicationTitle", "Mocale!"}
@@ -163,9 +158,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
     public void SetTranslationView_WhenTranslationKeyDoesNotExist_ShouldSetNotFoundKey()
     {
         // Arrange
-        var localization = new Localization()
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "MapplicationTitle", "Mocale!"}
@@ -189,9 +183,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
     public void SetTranslationView_WhenTranslationKeyExists_ShouldSetTranslation()
     {
         // Arrange
-        var localization = new Localization()
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "ApplicationTitle", "Mocale!"}
@@ -215,9 +208,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
     public void SetTranslationView_WhenUsingConverter_ShouldTranslateAndUseConverter()
     {
         // Arrange
-        var localization = new Localization()
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "ApplicationTitle", "Mocale!"}
@@ -270,9 +262,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
     public void SetTranslationBindingVoid_WhenTranslationKeyDoesNotExist_ShouldSetNotFoundKey()
     {
         // Arrange
-        var localization = new Localization()
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "MapplicationTitle", "Mocale!"},
@@ -298,9 +289,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
     public void SetTranslationBindingVoid_WhenTranslationKeyExists_ShouldFormatTranslation()
     {
         // Arrange
-        var localization = new Localization()
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "MapplicationTitle", "Mocale!" },
@@ -331,9 +321,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
     public void SetTranslationBindingVoid_WhenBindedValueChanges_ShouldUpdatedTranslation()
     {
         // Arrange
-        var localization = new Localization()
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "MapplicationTitle", "Mocale!" },
@@ -367,9 +356,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
     public void SetTranslationBindingVoid_WhenBindedValueString_ShouldUpdatedTranslation()
     {
         // Arrange
-        var localization = new Localization()
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "MapplicationTitle", "Mocale!" },
@@ -401,9 +389,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
     public void SetTranslationBindingVoid_WhenTranslationKeyExistsForCultureOneButNotCultureTwo_ShouldFormatTranslationCorrectly()
     {
         // Arrange
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "MapplicationTitle", "Mocale!" },
@@ -411,9 +398,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
             }
         };
 
-        var frFrLocalization = new Localization()
+        var frFrLocalization = new Localization(new CultureInfo("fr-FR"))
         {
-            CultureInfo = new CultureInfo("fr-FR"),
             Translations = new Dictionary<string, string>()
             {
                 { "MapplicationTitle", "Mocale!" },
@@ -446,9 +432,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
     public void SetTranslationBindingVoid_WhenTranslationKeyExistsForAllCultures_ShouldFormatTranslationCorrectly()
     {
         // Arrange
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "MapplicationTitle", "Mocale!" },
@@ -456,9 +441,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
             }
         };
 
-        var frFrLocalization = new Localization()
+        var frFrLocalization = new Localization(new CultureInfo("fr-FR"))
         {
-            CultureInfo = new CultureInfo("fr-FR"),
             Translations = new Dictionary<string, string>()
             {
                 { "MapplicationTitle", "Mocale!" },
@@ -521,9 +505,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
     public void SetTranslationBindingView_WhenTranslationKeyDoesNotExist_ShouldSetNotFoundKey()
     {
         // Arrange
-        var localization = new Localization()
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "MapplicationTitle", "Mocale!"},
@@ -550,9 +533,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
     public void SetTranslationBindingView_WhenTranslationKeyExists_ShouldFormatTranslation()
     {
         // Arrange
-        var localization = new Localization()
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "MapplicationTitle", "Mocale!" },
@@ -584,9 +566,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
     public void SetTranslationBindingView_WhenBindedValueChanges_ShouldUpdatedTranslation()
     {
         // Arrange
-        var localization = new Localization()
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "MapplicationTitle", "Mocale!" },
@@ -622,9 +603,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
     public void SetTranslationBindingView_WhenBindedValueString_ShouldUpdatedTranslation()
     {
         // Arrange
-        var localization = new Localization()
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "MapplicationTitle", "Mocale!" },
@@ -657,9 +637,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
     public void SetTranslationBindingView_WhenTranslationKeyExistsForCultureOneButNotCultureTwo_ShouldFormatTranslationCorrectly()
     {
         // Arrange
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "MapplicationTitle", "Mocale!" },
@@ -667,9 +646,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
             }
         };
 
-        var frFrLocalization = new Localization()
+        var frFrLocalization = new Localization(new CultureInfo("fr-FR"))
         {
-            CultureInfo = new CultureInfo("fr-FR"),
             Translations = new Dictionary<string, string>()
             {
                 { "MapplicationTitle", "Mocale!" },
@@ -703,9 +681,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
     public void SetTranslationBindingView_WhenTranslationKeyExistsForAllCultures_ShouldFormatTranslationCorrectly()
     {
         // Arrange
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "MapplicationTitle", "Mocale!" },
@@ -713,9 +690,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
             }
         };
 
-        var frFrLocalization = new Localization()
+        var frFrLocalization = new Localization(new CultureInfo("fr-FR"))
         {
-            CultureInfo = new CultureInfo("fr-FR"),
             Translations = new Dictionary<string, string>()
             {
                 { "MapplicationTitle", "Mocale!" },
@@ -817,9 +793,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
             }
         };
 
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "MapplicationTitle", "Mocale!" },
@@ -858,9 +833,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
             }
         };
 
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "Fruit_Apple", "Apple" },
@@ -901,9 +875,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
             }
         };
 
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "Fruit_Apple", "Apple" },
@@ -947,9 +920,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
             }
         };
 
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "Fruit_Apple", "Apple" },
@@ -958,9 +930,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
             }
         };
 
-        var frFrLocalization = new Localization()
+        var frFrLocalization = new Localization(new CultureInfo("fr-FR"))
         {
-            CultureInfo = new CultureInfo("fr-FR"),
             Translations = new Dictionary<string, string>()
             {
                 { "NotFruit", "Ce n'est pas un fruit" },
@@ -1003,9 +974,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
             }
         };
 
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "Fruit_Apple", "Apple" },
@@ -1014,9 +984,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
             }
         };
 
-        var frFrLocalization = new Localization()
+        var frFrLocalization = new Localization(new CultureInfo("fr-FR"))
         {
-            CultureInfo = new CultureInfo("fr-FR"),
             Translations = new Dictionary<string, string>()
             {
                 { "Fruit_Apple", "Pomme" },
@@ -1119,9 +1088,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
             }
         };
 
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "MapplicationTitle", "Mocale!" },
@@ -1161,9 +1129,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
             }
         };
 
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "Fruit_Apple", "Apple" },
@@ -1205,9 +1172,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
             }
         };
 
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "Fruit_Apple", "Apple" },
@@ -1252,9 +1218,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
             }
         };
 
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "Fruit_Apple", "Apple" },
@@ -1263,9 +1228,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
             }
         };
 
-        var frFrLocalization = new Localization()
+        var frFrLocalization = new Localization(new CultureInfo("fr-FR"))
         {
-            CultureInfo = new CultureInfo("fr-FR"),
             Translations = new Dictionary<string, string>()
             {
                 { "NotFruit", "Ce n'est pas un fruit" },
@@ -1309,9 +1273,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
             }
         };
 
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "Fruit_Apple", "Apple" },
@@ -1320,9 +1283,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
             }
         };
 
-        var frFrLocalization = new Localization()
+        var frFrLocalization = new Localization(new CultureInfo("fr-FR"))
         {
-            CultureInfo = new CultureInfo("fr-FR"),
             Translations = new Dictionary<string, string>()
             {
                 { "Fruit_Apple", "Pomme" },
@@ -1414,9 +1376,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         var nameBinding = new Binding(nameof(SomeViewModel.Name), source: viewModel);
         var fruitBinding = new Binding(nameof(SomeViewModel.SelectedFruit), source: viewModel);
 
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "NameTemperatureAndFruitLabel", "{0} likes {1}s when its {2} outside" }
@@ -1464,9 +1425,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         var nameBinding = new Binding(nameof(SomeViewModel.Name), source: viewModel);
         var fruitBinding = new Binding(nameof(SomeViewModel.SelectedFruit), source: viewModel);
 
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "NameTemperatureAndFruitLabel", "{0} likes {1}s when its {2} outside" }
@@ -1481,11 +1441,7 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         Assert.Equal("Jimmy likes Cherrys when its 19.2 outside", label.Text);
 
         // Act
-        var frFrLocalization = new Localization()
-        {
-            CultureInfo = new CultureInfo("fr-Fr"),
-            Translations = [],
-        };
+        var frFrLocalization = new Localization(new CultureInfo("fr-Fr"));
 
         translatorManager.UpdateTranslations(frFrLocalization, TranslationSource.Internal);
 
@@ -1510,9 +1466,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         var nameBinding = new Binding(nameof(SomeViewModel.Name), source: viewModel);
         var fruitBinding = new Binding(nameof(SomeViewModel.SelectedFruit), source: viewModel);
 
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "NameTemperatureAndFruitLabel", "{0} likes {1}s when its {2} outside" }
@@ -1527,9 +1482,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         Assert.Equal("Jimmy likes Cherrys when its 19.2 outside", label.Text);
 
         // Act
-        var frFrLocalization = new Localization()
+        var frFrLocalization = new Localization(new CultureInfo("fr-Fr"))
         {
-            CultureInfo = new CultureInfo("fr-Fr"),
             Translations = new Dictionary<string, string>()
             {
                 { "NameTemperatureAndFruitLabel", "{0} aime les {1} quand il est {2} dehors" }
@@ -1572,9 +1526,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         var nameBinding = new Binding(nameof(SomeViewModel.Name), source: viewModel);
         var fruitBinding = new Binding(nameof(SomeViewModel.SelectedFruit), source: viewModel);
 
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "NameTemperatureAndFruitLabel", "{0} likes {1}s when its {2} outside" }
@@ -1622,9 +1575,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         var nameBinding = new Binding(nameof(SomeViewModel.Name), source: viewModel);
         var fruitBinding = new Binding(nameof(SomeViewModel.SelectedFruit), source: viewModel);
 
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "NameTemperatureAndFruitLabel", "{0} likes {1}s when its {2} outside" }
@@ -1639,11 +1591,7 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         Assert.Equal("Jimmy likes Cherrys when its 19.2 outside", view.Text);
 
         // Act
-        var frFrLocalization = new Localization()
-        {
-            CultureInfo = new CultureInfo("fr-Fr"),
-            Translations = [],
-        };
+        var frFrLocalization = new Localization(new CultureInfo("fr-Fr"));
 
         translatorManager.UpdateTranslations(frFrLocalization, TranslationSource.Internal);
 
@@ -1668,9 +1616,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         var nameBinding = new Binding(nameof(SomeViewModel.Name), source: viewModel);
         var fruitBinding = new Binding(nameof(SomeViewModel.SelectedFruit), source: viewModel);
 
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "NameTemperatureAndFruitLabel", "{0} likes {1}s when its {2} outside" }
@@ -1685,9 +1632,8 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
         Assert.Equal("Jimmy likes Cherrys when its 19.2 outside", view.Text);
 
         // Act
-        var frFrLocalization = new Localization()
+        var frFrLocalization = new Localization(new CultureInfo("fr-Fr"))
         {
-            CultureInfo = new CultureInfo("fr-Fr"),
             Translations = new Dictionary<string, string>()
             {
                 { "NameTemperatureAndFruitLabel", "{0} aime les {1} quand il est {2} dehors" }

--- a/tests/Mocale.UnitTests/Extensions/LocalizeBindingExtensionTests.cs
+++ b/tests/Mocale.UnitTests/Extensions/LocalizeBindingExtensionTests.cs
@@ -235,9 +235,8 @@ public partial class LocalizeMultiBindingExtensionTests : FixtureBase<LocalizeBi
 
         Assert.Equal("$GreetingMessage$", label.Text);
 
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "GreetingMessage",  "Hello {0}" },
@@ -252,9 +251,8 @@ public partial class LocalizeMultiBindingExtensionTests : FixtureBase<LocalizeBi
 
         Assert.Equal("Hello Sir Dotsworth", label.Text);
 
-        var frFRLocalization = new Localization()
+        var frFRLocalization = new Localization(new CultureInfo("fr-FR"))
         {
-            CultureInfo = new CultureInfo("fr-FR"),
             Translations = new Dictionary<string, string>()
             {
                 { "GreetingMessage",  "Bonjour {0}" },
@@ -283,7 +281,7 @@ public partial class LocalizeMultiBindingExtensionTests : FixtureBase<LocalizeBi
     private sealed partial class GreetingViewModel : ObservableObject
     {
         [ObservableProperty]
-        public partial string Name { get; set; }
+        public partial string Name { get; set; } = string.Empty;
     }
 
     #endregion Test Data

--- a/tests/Mocale.UnitTests/Extensions/LocalizeEnumBehaviorExtensionTests.cs
+++ b/tests/Mocale.UnitTests/Extensions/LocalizeEnumBehaviorExtensionTests.cs
@@ -1,0 +1,72 @@
+using Mocale.Extensions;
+using Mocale.Models;
+
+namespace Mocale.UnitTests.Extensions;
+
+public class LocalizeEnumBehaviorExtensionTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ShouldLocalizeEnum_WhenEnumValueIsNotInOverrideRules_ShouldReturnGlobalUseAttribute(bool useAttribute)
+    {
+        // Arrange
+        var localizeEnumBehavior = new LocalizeEnumBehavior()
+        {
+            UseAttribute = useAttribute
+        };
+
+        var enumValue = EnumOne.A;
+
+        // Act
+        var result = localizeEnumBehavior.ShouldLocalizeEnum(enumValue);
+
+        // Assert
+        Assert.Equal(useAttribute, result);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(false, false)]
+    public void ShouldLocalizeEnum_WhenEnumValueIsInOverrideRules_ShouldReturnRuleUseAttribute(bool globalUseAttribute, bool ruleUseAttribute)
+    {
+        // Arrange
+        var localizeEnumBehavior = new LocalizeEnumBehavior()
+        {
+            UseAttribute = globalUseAttribute,
+            OverrideRules =
+            {
+                {
+                    typeof(EnumTwo), new LocalizeEnumRule()
+                    {
+                        UseAttribute = ruleUseAttribute,
+                    }
+                }
+            }
+        };
+
+        var enumValue = EnumTwo.Y;
+
+        // Act
+        var result = localizeEnumBehavior.ShouldLocalizeEnum(enumValue);
+
+        // Assert
+        Assert.Equal(ruleUseAttribute, result);
+    }
+
+    private enum EnumOne
+    {
+        A,
+        B,
+        C
+    }
+
+    private enum EnumTwo
+    {
+        X,
+        Y,
+        Z
+    }
+}

--- a/tests/Mocale.UnitTests/Extensions/LocalizeEnumExtensionTests.cs
+++ b/tests/Mocale.UnitTests/Extensions/LocalizeEnumExtensionTests.cs
@@ -22,7 +22,7 @@ public partial class LocalizeEnumExtensionTests : FixtureBase<LocalizeEnumExtens
 
     public override LocalizeEnumExtension CreateSystemUnderTest()
     {
-        return new LocalizeEnumExtension(mocaleConfiguration, translatorManager);
+        return new LocalizeEnumExtension(translatorManager);
     }
 
     #endregion Setup
@@ -42,11 +42,9 @@ public partial class LocalizeEnumExtensionTests : FixtureBase<LocalizeEnumExtens
         // Act
         var localizeExtension = new LocalizeEnumExtension();
         var extensionTranslatorManager = localizeExtension.GetTranslatorManager();
-        var extensionMocaleConfiguration = localizeExtension.GetMocaleConfiguration();
 
         // Assert
         Assert.Equal(translatorManagerMock.Object, extensionTranslatorManager);
-        Assert.Equal(configurationMock.Object, extensionMocaleConfiguration);
     }
 
     [Fact]
@@ -147,6 +145,8 @@ public partial class LocalizeEnumExtensionTests : FixtureBase<LocalizeEnumExtens
     public void Convert_WhenConfiguredToNotUseAttributes_ShouldReturnEnumString()
     {
         // Arrange
+        MocaleLocator.MocaleConfiguration = mocaleConfiguration;
+
         mocaleConfiguration.EnumBehavior = new LocalizeEnumBehavior
         {
             UseAttribute = false
@@ -163,9 +163,8 @@ public partial class LocalizeEnumExtensionTests : FixtureBase<LocalizeEnumExtens
     public void Convert_WhenConfiguredToUseAttributes_ShouldExtractFromConfiguredBehavior()
     {
         // Arrange
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "Key_Car",  "Car (English)" },
@@ -179,6 +178,8 @@ public partial class LocalizeEnumExtensionTests : FixtureBase<LocalizeEnumExtens
 
         translatorManager.UpdateTranslations(enGbLocalization, TranslationSource.Internal);
 
+        MocaleLocator.MocaleConfiguration = mocaleConfiguration;
+
         // Act
         var translationKey = Sut.Convert([new CultureInfo("en-GB"), Vehicle.Train], typeof(Label), null!, CultureInfo.InvariantCulture);
 
@@ -190,9 +191,8 @@ public partial class LocalizeEnumExtensionTests : FixtureBase<LocalizeEnumExtens
     public void Convert_WhenConfiguredToUseAttributesWithSpecificRule_ShouldExtractFromSpecificRule()
     {
         // Arrange
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "Key_Proteins",  "Proteins" },
@@ -204,6 +204,8 @@ public partial class LocalizeEnumExtensionTests : FixtureBase<LocalizeEnumExtens
         };
 
         translatorManager.UpdateTranslations(enGbLocalization, TranslationSource.Internal);
+
+        MocaleLocator.MocaleConfiguration = mocaleConfiguration;
 
         mocaleConfiguration.EnumBehavior = new LocalizeEnumBehavior
         {
@@ -232,9 +234,8 @@ public partial class LocalizeEnumExtensionTests : FixtureBase<LocalizeEnumExtens
     public void Convert_WhenConfiguredToNotUseAttributesButOverrideRuleExists_ShouldUseOverrideRuleOverGlobal()
     {
         // Arrange
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "Key_Proteins",  "Proteins" },
@@ -246,6 +247,8 @@ public partial class LocalizeEnumExtensionTests : FixtureBase<LocalizeEnumExtens
         };
 
         translatorManager.UpdateTranslations(enGbLocalization, TranslationSource.Internal);
+
+        MocaleLocator.MocaleConfiguration = mocaleConfiguration;
 
         mocaleConfiguration.EnumBehavior = new LocalizeEnumBehavior
         {
@@ -279,6 +282,7 @@ public partial class LocalizeEnumExtensionTests : FixtureBase<LocalizeEnumExtens
     [Fact]
     public void IntegrationTest()
     {
+        MocaleLocator.MocaleConfiguration = mocaleConfiguration;
         _ = new ControlsFixtureBase();
         var label = new Label();
 
@@ -291,9 +295,8 @@ public partial class LocalizeEnumExtensionTests : FixtureBase<LocalizeEnumExtens
 
         Assert.Equal("", label.Text);
 
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "Key_Car",  "Car (English)" },
@@ -313,9 +316,8 @@ public partial class LocalizeEnumExtensionTests : FixtureBase<LocalizeEnumExtens
 
         Assert.Equal("Bicycle (English)", label.Text);
 
-        var frFRLocalization = new Localization()
+        var frFRLocalization = new Localization(new CultureInfo("fr-FR"))
         {
-            CultureInfo = new CultureInfo("fr-FR"),
             Translations = new Dictionary<string, string>()
             {
                 { "Key_Car",  "Voiture (Français)" },

--- a/tests/Mocale.UnitTests/Extensions/LocalizeExtensionTests.cs
+++ b/tests/Mocale.UnitTests/Extensions/LocalizeExtensionTests.cs
@@ -120,9 +120,8 @@ public class LocalizeExtensionTests : FixtureBase<LocalizeExtension>
 
         Assert.Equal("$IntegrationTestMessage$", label.Text);
 
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "IntegrationTestMessage", "This is my localization running in an integration test" }
@@ -133,9 +132,8 @@ public class LocalizeExtensionTests : FixtureBase<LocalizeExtension>
 
         Assert.Equal("This is my localization running in an integration test", label.Text);
 
-        var frFRLocalization = new Localization()
+        var frFRLocalization = new Localization(new CultureInfo("fr-FR"))
         {
-            CultureInfo = new CultureInfo("fr-FR"),
             Translations = new Dictionary<string, string>()
             {
                 { "IntegrationTestMessage", "Ceci est ma localisation en cours d'exécution dans un test d'intégration" }

--- a/tests/Mocale.UnitTests/Extensions/LocalizeMultiBindingTests.cs
+++ b/tests/Mocale.UnitTests/Extensions/LocalizeMultiBindingTests.cs
@@ -323,9 +323,8 @@ public partial class LocalizeMultiBindingTests : FixtureBase<LocalizeMultiBindin
         Sut.Bindings.Add(dateBinding);
         Sut.Bindings.Add(temperatureBinding);
 
-        var frFrLocalization = new Localization()
+        var frFrLocalization = new Localization(new CultureInfo("fr-FR"))
         {
-            CultureInfo = new CultureInfo("fr-FR"),
             Translations = new Dictionary<string, string>()
             {
                 { "WelcomeMessage", "Bonjour {0}, La date est le {1} et la température est le {2}\u00b0C" }
@@ -368,9 +367,8 @@ public partial class LocalizeMultiBindingTests : FixtureBase<LocalizeMultiBindin
         Sut.Bindings.Add(dateBinding);
         Sut.Bindings.Add(temperatureBinding);
 
-        var enGbLocalization = new Localization()
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "WelcomeMessage", "Hello {0}, The date is {1} and the temperature is {2}\u00b0C" }
@@ -393,9 +391,8 @@ public partial class LocalizeMultiBindingTests : FixtureBase<LocalizeMultiBindin
         Assert.Equal("Hello Helen, The date is 02/03/2025 13:42:23 and the temperature is 10.3\u00b0C", label.Text);
 
         // Language changes => text should update
-        var frFrLocalization = new Localization()
+        var frFrLocalization = new Localization(new CultureInfo("fr-FR"))
         {
-            CultureInfo = new CultureInfo("fr-FR"),
             Translations = new Dictionary<string, string>()
             {
                 { "WelcomeMessage", "Bonjour {0}, La date est le {1} et la température est le {2}\u00b0C" }
@@ -420,7 +417,7 @@ public partial class LocalizeMultiBindingTests : FixtureBase<LocalizeMultiBindin
     private sealed partial class GreetingsViewModel : ObservableObject
     {
         [ObservableProperty]
-        public partial string Name { get; set; }
+        public partial string Name { get; set; } = string.Empty;
 
         [ObservableProperty]
         public partial double Temperature { get; set; }

--- a/tests/Mocale.UnitTests/Extensions/TranslatorManagerExtensionsTests.cs
+++ b/tests/Mocale.UnitTests/Extensions/TranslatorManagerExtensionsTests.cs
@@ -78,7 +78,7 @@ public class TranslatorManagerExtensionsTests : FixtureBase<ITranslatorManager>
         var translation = Sut.TranslateEnum(DescriptionAttributeEnum.Value2);
 
         // Assert
-        Assert.Equal("$Value2$", translation);
+        Assert.Equal("Value2", translation);
     }
 
     [Fact]

--- a/tests/Mocale.UnitTests/Extensions/TranslatorManagerExtensionsTests.cs
+++ b/tests/Mocale.UnitTests/Extensions/TranslatorManagerExtensionsTests.cs
@@ -1,0 +1,222 @@
+using System.ComponentModel;
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+using Mocale.Abstractions;
+using Mocale.Enums;
+using Mocale.Extensions;
+using Mocale.Managers;
+using Mocale.Models;
+using Mocale.Testing;
+using Mocale.UnitTests.Collections;
+
+namespace Mocale.UnitTests.Extensions;
+
+[Collection(CollectionNames.MocaleLocatorTests)]
+public class TranslatorManagerExtensionsTests : FixtureBase<ITranslatorManager>
+{
+    #region Setup
+
+    private readonly Mock<IMocaleConfiguration> mocaleConfiguration = new();
+    private readonly TranslatorManagerProxy translatorManager = new();
+
+    public override ITranslatorManager CreateSystemUnderTest()
+    {
+        MocaleLocator.MocaleConfiguration = mocaleConfiguration.Object;
+
+        return translatorManager;
+    }
+
+    #endregion Setup
+
+    #region Tests
+
+    [Fact]
+    public void TranslateEnum_WhenEnumHasNoAttributes_ShouldUseValueToString()
+    {
+        // Arrange
+        mocaleConfiguration.SetupGet(m => m.EnumBehavior)
+            .Returns(new LocalizeEnumBehavior());
+
+        translatorManager.UpdateTranslations(new Localization(new CultureInfo("en-GB"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "Value1", "Value One"},
+                { "Value2", "Value Two"},
+                { "Value13", "Value Three"}
+            }
+        }, TranslationSource.Internal);
+
+        // Act
+        var translation = Sut.TranslateEnum(NoAttributeEnum.Value2);
+
+        // Assert
+        Assert.Equal("Value Two", translation);
+    }
+
+    [Fact]
+    public void TranslateEnum_WhenEnumHasAttributesButDisabledViaConfig_ShouldUseValueToString()
+    {
+        // Arrange
+        mocaleConfiguration.SetupGet(m => m.EnumBehavior)
+            .Returns(new LocalizeEnumBehavior()
+            {
+                UseAttribute = false,
+            });
+
+        translatorManager.UpdateTranslations(new Localization(new CultureInfo("en-GB"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "Value1Key", "Value One"},
+                { "Value2Key", "Value Two"},
+                { "Value3Key", "Value Three"}
+            }
+        }, TranslationSource.Internal);
+
+        // Act
+        var translation = Sut.TranslateEnum(DescriptionAttributeEnum.Value2);
+
+        // Assert
+        Assert.Equal("$Value2$", translation);
+    }
+
+    [Fact]
+    public void TranslateEnum_WhenDefaultEnumConfig_ShouldUseDescriptionAttribute()
+    {
+        // Arrange
+        mocaleConfiguration.SetupGet(m => m.EnumBehavior)
+            .Returns(new LocalizeEnumBehavior());
+
+        translatorManager.UpdateTranslations(new Localization(new CultureInfo("en-GB"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "Value1Key", "Value One"},
+                { "Value2Key", "Value Two"},
+                { "Value3Key", "Value Three"}
+            }
+        }, TranslationSource.Internal);
+
+        // Act
+        var translation = Sut.TranslateEnum(DescriptionAttributeEnum.Value3);
+
+        // Assert
+        Assert.Equal("Value Three", translation);
+    }
+
+    [Fact]
+    public void TranslateEnum_WhenCustomEnumConfig_ShouldUseConfigAttribute()
+    {
+        // Arrange
+        mocaleConfiguration.SetupGet(m => m.EnumBehavior)
+            .Returns(new LocalizeEnumBehavior()
+            {
+                LocalizeAttribute = typeof(LocalizationKeyAttribute),
+                AttributePropertyName = nameof(LocalizationKeyAttribute.Key),
+                UseAttribute = true
+            });
+
+        translatorManager.UpdateTranslations(new Localization(new CultureInfo("en-GB"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "RightKeyOne", "Custom Value One"},
+                { "RightKeyTwo", "Custom Value Two"},
+                { "RightKeyThree", "Custom Value Three"}
+            }
+        }, TranslationSource.Internal);
+
+        // Act
+        var translation = Sut.TranslateEnum(CustomAttributeEnum.Value1);
+
+        // Assert
+        Assert.Equal("Custom Value One", translation);
+    }
+
+    [Fact]
+    public void TranslateEnum_WhenSpecificEnumRule_ShouldUseRuleAttribute()
+    {
+        // Arrange
+        mocaleConfiguration.SetupGet(m => m.EnumBehavior)
+            .Returns(new LocalizeEnumBehavior()
+            {
+                LocalizeAttribute = typeof(DescriptionAttribute),
+                AttributePropertyName = nameof(DescriptionAttribute.Description),
+                UseAttribute = true,
+                OverrideRules =
+                {
+                    {
+                        typeof(CustomAttributeEnum), new LocalizeEnumRule()
+                        {
+                            LocalizeAttribute = typeof(LocalizationKeyAttribute),
+                            AttributePropertyName = nameof(LocalizationKeyAttribute.Key),
+                            UseAttribute = true,
+                        }
+                    }
+                }
+            });
+
+        translatorManager.UpdateTranslations(new Localization(new CultureInfo("en-GB"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "RightKeyOne", "Custom Value One"},
+                { "RightKeyTwo", "Custom Value Two"},
+                { "RightKeyThree", "Custom Value Three"}
+            }
+        }, TranslationSource.Internal);
+
+        // Act
+        var translation = Sut.TranslateEnum(CustomAttributeEnum.Value2);
+
+        // Assert
+        Assert.Equal("Custom Value Two", translation);
+    }
+
+    #endregion Tests
+
+    #region Test Data
+
+    private enum NoAttributeEnum
+    {
+        Value1,
+        Value2,
+        Value3
+    }
+
+    private enum DescriptionAttributeEnum
+    {
+        [Description("Value1Key")]
+        Value1,
+
+        [Description("Value2Key")]
+        Value2,
+
+        [Description("Value3Key")]
+        Value3
+    }
+
+    private enum CustomAttributeEnum
+    {
+        [Description("WRONG KEY 1")]
+        [LocalizationKey("RightKeyOne")]
+        Value1,
+
+        [Description("WRONG KEY 2")]
+        [LocalizationKey("RightKeyTwo")]
+        Value2,
+
+        [Description("WRONG KEY 3")]
+        [LocalizationKey("RightKeyThree")]
+        Value3,
+    }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    private class LocalizationKeyAttribute(string key) : Attribute
+    {
+        public string Key { get; } = key;
+    }
+
+    #endregion Test Data
+}

--- a/tests/Mocale.UnitTests/Helpers/EnumTranslationKeyHelperTests.cs
+++ b/tests/Mocale.UnitTests/Helpers/EnumTranslationKeyHelperTests.cs
@@ -25,11 +25,9 @@ public class EnumTranslationKeyHelperTests
     public void GetTranslationKey_WhenEnumHasNoAttribute_ShouldSetEnumStringValue()
     {
         // Arrange
-        var config = new MocaleConfiguration();
-        var helper = new EnumTranslationKeyHelper(config);
 
         // Act
-        var result = helper.GetTranslationKey(TestEnum.ValueWithoutAttribute);
+        var result = EnumTranslationKeyHelper.GetTranslationKey(TestEnum.ValueWithoutAttribute, new LocalizeEnumBehavior());
 
         // Assert
         Assert.Equal("ValueWithoutAttribute", result);
@@ -39,20 +37,15 @@ public class EnumTranslationKeyHelperTests
     public void GetTranslationKey_WhenEnumHasNoOverrideRules_ShouldGetKeyFromGlobalConfig()
     {
         // Arrange
-        var config = new MocaleConfiguration
+        var behavior = new LocalizeEnumBehavior
         {
-            EnumBehavior = new LocalizeEnumBehavior
-            {
-                UseAttribute = true,
-                LocalizeAttribute = typeof(DescriptionAttribute),
-                AttributePropertyName = nameof(DescriptionAttribute.Description),
-            }
+            UseAttribute = true,
+            LocalizeAttribute = typeof(DescriptionAttribute),
+            AttributePropertyName = nameof(DescriptionAttribute.Description),
         };
 
-        var helper = new EnumTranslationKeyHelper(config);
-
         // Act
-        var result = helper.GetTranslationKey(TestEnum.ValueWithAttribute);
+        var result = EnumTranslationKeyHelper.GetTranslationKey(TestEnum.ValueWithAttribute, behavior);
 
         // Assert
         Assert.Equal("LocalizedName", result);
@@ -62,18 +55,13 @@ public class EnumTranslationKeyHelperTests
     public void GetTranslationKey_WhenConfigShouldNotUseAttribute_ShouldGetKeyFromToString()
     {
         // Arrange
-        var config = new MocaleConfiguration
+        var behavior = new LocalizeEnumBehavior
         {
-            EnumBehavior = new LocalizeEnumBehavior
-            {
-                UseAttribute = false,
-            }
+            UseAttribute = false,
         };
 
-        var helper = new EnumTranslationKeyHelper(config);
-
         // Act
-        var result = helper.GetTranslationKey(TestEnum.ValueWithAttribute);
+        var result = EnumTranslationKeyHelper.GetTranslationKey(TestEnum.ValueWithAttribute, behavior);
 
         // Assert
         Assert.Equal("ValueWithAttribute", result);
@@ -83,27 +71,22 @@ public class EnumTranslationKeyHelperTests
     public void GetTranslationKey_WhenEnumHasOverrideRules_ShouldUseSpecificRulesForEnum()
     {
         // Arrange
-        var config = new MocaleConfiguration
+        var behavior = new LocalizeEnumBehavior
         {
-            EnumBehavior = new LocalizeEnumBehavior
-            {
-                UseAttribute = false,
-                LocalizeAttribute = typeof(Attribute),
-                AttributePropertyName = "???",
-            }
+            UseAttribute = false,
+            LocalizeAttribute = typeof(Attribute),
+            AttributePropertyName = "???",
         };
 
-        config.EnumBehavior.OverrideRules.Add(typeof(TestEnum), new LocalizeEnumRule()
+        behavior.OverrideRules.Add(typeof(TestEnum), new LocalizeEnumRule()
         {
             UseAttribute = true,
             LocalizeAttribute = typeof(CustomTranslationKeyAttribute),
             AttributePropertyName = nameof(CustomTranslationKeyAttribute.TranslationKey),
         });
 
-        var helper = new EnumTranslationKeyHelper(config);
-
         // Act
-        var result = helper.GetTranslationKey(TestEnum.ValueWithAttribute);
+        var result = EnumTranslationKeyHelper.GetTranslationKey(TestEnum.ValueWithAttribute, behavior);
 
         // Assert
         Assert.Equal("BingBongKey", result);

--- a/tests/Mocale.UnitTests/Managers/LocalizationManagerTests.cs
+++ b/tests/Mocale.UnitTests/Managers/LocalizationManagerTests.cs
@@ -1,11 +1,9 @@
-using System;
 using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Mocale.Abstractions;
 using Mocale.Enums;
 using Mocale.Managers;
 using Mocale.Models;
-using Mocale.Testing;
 using Mocale.UnitTests.Collections;
 
 namespace Mocale.UnitTests.Managers;
@@ -146,9 +144,8 @@ public class LocalizationManagerTests : FixtureBase<ILocalizationManager>, IDisp
         var loadResult = new TranslationLoadResult()
         {
             Loaded = true,
-            Localization = new Localization()
+            Localization = new Localization(activeCulture)
             {
-                CultureInfo = activeCulture,
                 Translations = new Dictionary<string, string>()
                     {
                         { "KeyOne", "Ciao mondo!" },
@@ -191,9 +188,8 @@ public class LocalizationManagerTests : FixtureBase<ILocalizationManager>, IDisp
         var loadResult = new TranslationLoadResult()
         {
             Loaded = true,
-            Localization = new Localization()
+            Localization = new Localization(activeCulture)
             {
-                CultureInfo = activeCulture,
                 Translations = new Dictionary<string, string>()
                     {
                         { "KeyOne", "Ciao mondo!" },
@@ -236,9 +232,8 @@ public class LocalizationManagerTests : FixtureBase<ILocalizationManager>, IDisp
         var loadResult = new TranslationLoadResult()
         {
             Loaded = true,
-            Localization = new Localization()
+            Localization = new Localization(activeCulture)
             {
-                CultureInfo = activeCulture,
                 Translations = new Dictionary<string, string>()
                     {
                         { "KeyOne", "Ciao mondo!" },
@@ -281,9 +276,8 @@ public class LocalizationManagerTests : FixtureBase<ILocalizationManager>, IDisp
         var localLoadResult = new TranslationLoadResult()
         {
             Loaded = true,
-            Localization = new Localization()
+            Localization = new Localization(activeCulture)
             {
-                CultureInfo = activeCulture,
                 Translations = new Dictionary<string, string>()
                     {
                         { "KeyOne", "Ciao mondo!" },
@@ -348,9 +342,8 @@ public class LocalizationManagerTests : FixtureBase<ILocalizationManager>, IDisp
         var localLoadResult = new TranslationLoadResult()
         {
             Loaded = true,
-            Localization = new Localization()
+            Localization = new Localization(activeCulture)
             {
-                CultureInfo = activeCulture,
                 Translations = new Dictionary<string, string>()
                     {
                         { "KeyOne", "Ciao mondo!" },
@@ -365,9 +358,8 @@ public class LocalizationManagerTests : FixtureBase<ILocalizationManager>, IDisp
         var externalLoadResult = new TranslationLoadResult()
         {
             Loaded = true,
-            Localization = new Localization()
+            Localization = new Localization(activeCulture)
             {
-                CultureInfo = activeCulture,
                 Translations = new Dictionary<string, string>()
                 {
                     { "KeyOne", "External Ciao mondo!" },
@@ -455,9 +447,8 @@ public class LocalizationManagerTests : FixtureBase<ILocalizationManager>, IDisp
         var loadResult = new TranslationLoadResult()
         {
             Loaded = true,
-            Localization = new Localization()
+            Localization = new Localization(activeCulture)
             {
-                CultureInfo = activeCulture,
                 Translations = new Dictionary<string, string>()
                 {
                     { "KeyOne", "Ciao mondo!" },
@@ -503,9 +494,8 @@ public class LocalizationManagerTests : FixtureBase<ILocalizationManager>, IDisp
         var loadResult = new TranslationLoadResult()
         {
             Loaded = true,
-            Localization = new Localization()
+            Localization = new Localization(activeCulture)
             {
-                CultureInfo = activeCulture,
                 Translations = new Dictionary<string, string>()
                 {
                     { "KeyOne", "Ciao mondo!" },
@@ -551,9 +541,8 @@ public class LocalizationManagerTests : FixtureBase<ILocalizationManager>, IDisp
         var loadResult = new TranslationLoadResult()
         {
             Loaded = true,
-            Localization = new Localization()
+            Localization = new Localization(activeCulture)
             {
-                CultureInfo = activeCulture,
                 Translations = new Dictionary<string, string>()
                 {
                     { "KeyOne", "Ciao mondo!" },
@@ -595,9 +584,8 @@ public class LocalizationManagerTests : FixtureBase<ILocalizationManager>, IDisp
             .Returns(new TranslationLoadResult()
             {
                 Loaded = true,
-                Localization = new Localization()
+                Localization = new Localization(new CultureInfo("it-IT"))
                 {
-                    CultureInfo = new CultureInfo("it-IT"),
                     Translations = new Dictionary<string, string>()
                     {
                         { "Hello", "Ciao!" }
@@ -730,9 +718,8 @@ public class LocalizationManagerTests : FixtureBase<ILocalizationManager>, IDisp
             {
                 Loaded = true,
                 Source = TranslationSource.Internal,
-                Localization = new Localization()
+                Localization = new Localization(new CultureInfo("fr-FR"))
                 {
-                    CultureInfo = new CultureInfo("fr-FR"),
                     Translations = new Dictionary<string, string>()
                     {
                         { "KeyOne", "Bonjour madame" },
@@ -778,9 +765,8 @@ public class LocalizationManagerTests : FixtureBase<ILocalizationManager>, IDisp
         var externalLoadResult = new TranslationLoadResult()
         {
             Loaded = true,
-            Localization = new Localization()
+            Localization = new Localization(newCulture)
             {
-                CultureInfo = newCulture,
                 Translations = new Dictionary<string, string>()
                 {
                     { "KeyOne", "External Bonjour le monde" },
@@ -795,9 +781,8 @@ public class LocalizationManagerTests : FixtureBase<ILocalizationManager>, IDisp
         var localLoadResult = new TranslationLoadResult()
         {
             Loaded = true,
-            Localization = new Localization()
+            Localization = new Localization(newCulture)
             {
-                CultureInfo = newCulture,
                 Translations = new Dictionary<string, string>()
                 {
                     { "KeyOne", "Bonjour le monde" },
@@ -853,9 +838,8 @@ public class LocalizationManagerTests : FixtureBase<ILocalizationManager>, IDisp
         var externalLoadResult = new TranslationLoadResult()
         {
             Loaded = true,
-            Localization = new Localization()
+            Localization = new Localization(newCulture)
             {
-                CultureInfo = newCulture,
                 Translations = new Dictionary<string, string>()
                 {
                     { "KeyOne", "External Bonjour le monde" },
@@ -973,9 +957,8 @@ public class LocalizationManagerTests : FixtureBase<ILocalizationManager>, IDisp
         var localLoadResult = new TranslationLoadResult()
         {
             Loaded = true,
-            Localization = new Localization()
+            Localization = new Localization(newCulture)
             {
-                CultureInfo = newCulture,
                 Translations = new Dictionary<string, string>()
                 {
                     { "KeyOne", "Bonjour le monde" },
@@ -1033,9 +1016,8 @@ public class LocalizationManagerTests : FixtureBase<ILocalizationManager>, IDisp
         var localLoadResult = new TranslationLoadResult()
         {
             Loaded = true,
-            Localization = new Localization()
+            Localization = new Localization(newCulture)
             {
-                CultureInfo = newCulture,
                 Translations = new Dictionary<string, string>()
                 {
                     { "KeyOne", "Bonjour le monde" },

--- a/tests/Mocale.UnitTests/Managers/TranslatorManagerTests.cs
+++ b/tests/Mocale.UnitTests/Managers/TranslatorManagerTests.cs
@@ -33,11 +33,7 @@ public class TranslatorManagerTests : FixtureBase
 
         Assert.Null(sut.CurrentCulture);
 
-        var localization = new Localization()
-        {
-            CultureInfo = new CultureInfo("en-GB"),
-            Translations = []
-        };
+        var localization = new Localization(new CultureInfo("en-GB"));
 
         // Act
         sut.UpdateTranslations(localization, TranslationSource.Internal);
@@ -54,9 +50,8 @@ public class TranslatorManagerTests : FixtureBase
         // Arrange
         var sut = GetSut<TranslatorManager>();
 
-        var localization = new Localization()
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "HelloWorld", "Hello World" },
@@ -81,9 +76,8 @@ public class TranslatorManagerTests : FixtureBase
         // Arrange
         var sut = GetSut<TranslatorManager>();
 
-        var localization = new Localization()
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "HelloWorld", "Hello World" },
@@ -108,9 +102,8 @@ public class TranslatorManagerTests : FixtureBase
         // Arrange
         var sut = GetSut<TranslatorManager>();
 
-        var localization = new Localization()
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "HelloWorld", "Hello World" },
@@ -135,9 +128,8 @@ public class TranslatorManagerTests : FixtureBase
         // Arrange
         var sut = GetSut<TranslatorManager>();
 
-        var localization = new Localization()
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "HelloWorld", "Hello World" },
@@ -162,9 +154,8 @@ public class TranslatorManagerTests : FixtureBase
         // Arrange
         var sut = GetSut<TranslatorManager>();
 
-        var localization = new Localization()
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "HelloWorld", "Hello World" },
@@ -191,9 +182,8 @@ public class TranslatorManagerTests : FixtureBase
         // Arrange
         var sut = GetSut<TranslatorManager>();
 
-        var localization = new Localization()
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string>()
             {
                 { "HelloWorld", "Hello World" },
@@ -218,9 +208,8 @@ public class TranslatorManagerTests : FixtureBase
     public void Translate_WhenExternalLocalizationsContainsKey_ShouldReturnLocalization()
     {
         // Arrange
-        var localization = new Localization
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string> { { "KeyOne", "I am the first key" } }
         };
 
@@ -241,9 +230,8 @@ public class TranslatorManagerTests : FixtureBase
     public void Translate_WhenInternalLocalizationsContainsKey_ShouldReturnLocalization()
     {
         // Arrange
-        var localization = new Localization
+        var localization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string> { { "KeyOne", "I am the first key" } }
         };
 
@@ -306,15 +294,13 @@ public class TranslatorManagerTests : FixtureBase
     public void Translate_WhenCultureChanges_ShouldReturnNewLocalization()
     {
         // Arrange
-        var englishLocalization = new Localization
+        var englishLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string> { { "KeyOne", "I am the first key" } }
         };
 
-        var frenchLocalization = new Localization
+        var frenchLocalization = new Localization(new CultureInfo("fr-FR"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string> { { "KeyOne", "je suis la première clé" } }
         };
 
@@ -335,15 +321,13 @@ public class TranslatorManagerTests : FixtureBase
     public void Translate_WhenCultureChangesAndNewCultureDoesntContainKey_ShouldReturnMissing()
     {
         // Arrange
-        var englishLocalization = new Localization
+        var englishLocalization = new Localization(new CultureInfo("en-GB"))
         {
-            CultureInfo = new CultureInfo("en-GB"),
             Translations = new Dictionary<string, string> { { "KeyOne", "I am the first key" } }
         };
 
-        var frenchLocalization = new Localization
+        var frenchLocalization = new Localization(new CultureInfo("fr-FR"))
         {
-            CultureInfo = new CultureInfo("fr-FR"),
             Translations = new Dictionary<string, string> { { "KeyTwo", "je suis la deuxième clé" } }
         };
 

--- a/tests/Mocale.UnitTests/Testing/TranslatorManagerProxyTests.cs
+++ b/tests/Mocale.UnitTests/Testing/TranslatorManagerProxyTests.cs
@@ -54,23 +54,20 @@ public class TranslatorManagerProxyTests : FixtureBase<TranslatorManagerProxy>
 
         // Act
         Sut.UpdateTranslations(
-            new Localization
+            new Localization(new CultureInfo("en-GB"))
             {
-                CultureInfo = new CultureInfo("en-GB"),
                 Translations = new Dictionary<string, string> { { "KeyOne", "Hello" }, { "KeyTwo", "World" } }
             }, TranslationSource.External);
 
         Sut.UpdateTranslations(
-            new Localization
+            new Localization(new CultureInfo("en-GB"))
             {
-                CultureInfo = new CultureInfo("en-GB"),
                 Translations = new Dictionary<string, string> { { "KeyOne", "Hello" }, { "KeyTwo", "World" } }
             }, TranslationSource.WarmCache);
 
         Sut.UpdateTranslations(
-            new Localization
+            new Localization(new CultureInfo("en-GB"))
             {
-                CultureInfo = new CultureInfo("en-GB"),
                 Translations = new Dictionary<string, string> { { "KeyOne", "Hello" }, { "KeyTwo", "World" } }
             }, TranslationSource.ColdCache);
 
@@ -100,9 +97,8 @@ public class TranslatorManagerProxyTests : FixtureBase<TranslatorManagerProxy>
 
         // Act
         Sut.UpdateTranslations(
-            new Localization
+            new Localization(new CultureInfo("en-GB"))
             {
-                CultureInfo = new CultureInfo("en-GB"),
                 Translations = new Dictionary<string, string> { { "KeyOne", "Hello" }, { "KeyTwo", "World" } }
             }, TranslationSource.Internal);
 
@@ -133,23 +129,20 @@ public class TranslatorManagerProxyTests : FixtureBase<TranslatorManagerProxy>
 
         // Act
         Sut.UpdateTranslations(
-            new Localization
+            new Localization(new CultureInfo("en-GB"))
             {
-                CultureInfo = new CultureInfo("en-GB"),
                 Translations = new Dictionary<string, string> { { "KeyOne", "Hello" }, { "KeyTwo", "World" } }
             }, TranslationSource.External, false);
 
         Sut.UpdateTranslations(
-            new Localization
+            new Localization(new CultureInfo("en-GB"))
             {
-                CultureInfo = new CultureInfo("en-GB"),
                 Translations = new Dictionary<string, string> { { "KeyOne", "Hello" }, { "KeyTwo", "World" } }
             }, TranslationSource.WarmCache, false);
 
         Sut.UpdateTranslations(
-            new Localization
+            new Localization(new CultureInfo("en-GB"))
             {
-                CultureInfo = new CultureInfo("en-GB"),
                 Translations = new Dictionary<string, string> { { "KeyOne", "Hello" }, { "KeyTwo", "World" } }
             }, TranslationSource.ColdCache, false);
 
@@ -179,9 +172,8 @@ public class TranslatorManagerProxyTests : FixtureBase<TranslatorManagerProxy>
 
         // Act
         Sut.UpdateTranslations(
-            new Localization
+            new Localization(new CultureInfo("en-GB"))
             {
-                CultureInfo = new CultureInfo("en-GB"),
                 Translations = new Dictionary<string, string> { { "KeyOne", "Hello" }, { "KeyTwo", "World" } }
             }, TranslationSource.Internal, false);
 


### PR DESCRIPTION
As I was updating my own apps I came across the need for a couple of methods that weren't being exposed by what I added to the library.

The new things we have are:

- `translatorManager.TranslateEnum(Fruit.Apple);`
- `label.SetTranslateEnumValue(Label.TextProperty, Fruit.Cherry);`

Both of these are just candy around what was already in the translate enum extension. Firstly the direct translate method means consumers no longer have to find the keys for the enums, mocale handles it. The `SetTranslateEnumValue` method allows you to localize static enum values without needing to create an extra binding. This would be useful for controls etc.

Some refactoring has occured in this PR as I pulled the trigger on cleaning up `Localization`, this shouldn't massively impact external code (I hope). I've also marked the translate methods to return `string`, not `string?`. I think I was scared to use `string.Empty` when I originally wrote this part of the library as I was new to `#nullable`, frankly having the translator manager declare a nullable string but always return a string made little to no sense!