### PR TITLE
Add KeySelector For Bindings & Test Helpers

### DIFF
--- a/samples/Mocale.Samples/AppShell.xaml
+++ b/samples/Mocale.Samples/AppShell.xaml
@@ -17,5 +17,7 @@
         <ShellContent Title="{mocale:Localize Key={x:Static keys:TranslationKeys.ParameterPageTitle}}" ContentTemplate="{DataTemplate pages:ParameterPage}" />
 
         <ShellContent Title="{mocale:Localize Key={x:Static keys:TranslationKeys.CodePageTitle}}" ContentTemplate="{DataTemplate pages:CodePage}" />
+
+        <ShellContent Title="{mocale:Localize Key={x:Static keys:TranslationKeys.ConverterPageTitle}}" ContentTemplate="{DataTemplate pages:ConverterPage}" />
     </FlyoutItem>
 </Shell>

--- a/samples/Mocale.Samples/MauiProgram.cs
+++ b/samples/Mocale.Samples/MauiProgram.cs
@@ -80,10 +80,12 @@ public static class MauiProgram
         builder.Services.AddTransient<BindingPage>();
         builder.Services.AddTransient<IntroductionPage>();
         builder.Services.AddTransient<ParameterPage>();
+        builder.Services.AddTransient<ConverterPage>();
 
         builder.Services.AddTransient<IntroductionPageViewModel>();
         builder.Services.AddTransient<BindingViewModel>();
         builder.Services.AddTransient<ParameterViewModel>();
+        builder.Services.AddTransient<ConverterViewModel>();
 
         return builder.Build();
     }

--- a/samples/Mocale.Samples/Mocale.Samples.csproj
+++ b/samples/Mocale.Samples/Mocale.Samples.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <LangVersion>preview</LangVersion>
@@ -12,6 +12,7 @@
     <GenerateSatelliteAssembliesForCore>true</GenerateSatelliteAssembliesForCore>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
 
     <!-- Display name -->
     <ApplicationTitle>Mocale.Samples</ApplicationTitle>
@@ -97,5 +98,7 @@
 
   <Import Project="..\..\src\Mocale.SourceGenerators\build\Package.props" />
   <Import Project="..\..\src\Mocale.SourceGenerators\build\Package.targets" />
+  <Import Project="..\..\src\Mocale\build\Package.props" />
+  <Import Project="..\..\src\Mocale\build\Package.targets" />
 
 </Project>

--- a/samples/Mocale.Samples/Pages/ConverterPage.xaml
+++ b/samples/Mocale.Samples/Pages/ConverterPage.xaml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<!--  ReSharper disable Xaml.InvalidType  -->
+<pages:BasePage
+    x:Class="Mocale.Samples.Pages.ConverterPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:keys="clr-namespace:Mocale.Translations"
+    xmlns:mocale="http://axemasta.com/schemas/2022/mocale"
+    xmlns:pages="clr-namespace:Mocale.Samples.Pages"
+    xmlns:viewmodels="clr-namespace:Mocale.Samples.ViewModels"
+    Title="{mocale:Localize Key={x:Static keys:TranslationKeys.ConverterPageTitle}}"
+    x:DataType="viewmodels:ConverterViewModel"
+    x:TypeArguments="viewmodels:ConverterViewModel">
+
+    <ContentPage.Resources>
+        <pages:SpongebobCaseConverter x:Key="PostTranslationConverter" />
+        <pages:OrderStatusKeySelector x:Key="KeySelectorConverter" />
+    </ContentPage.Resources>
+
+    <ScrollView>
+        <VerticalStackLayout
+            HorizontalOptions="Fill"
+            Spacing="20"
+            VerticalOptions="Start">
+            <Label Text="Mocale markup extensions support IValueConverters however when binding to a value there is a twist. Normally an IValueConverter is used to convert an object to another value based on the requirements in your view. When localizing this adds a layer of complication, does the converter supply the key or does it deal with the translated value. Since Mocale is doing a conversion of its own (key to localization) there is the concept of KeyConverters and ValueConverters. A key converter allows you to select a translation key based on a binding and the ValueConverter is applied after the translation for any final processing that might be required." />
+
+            <Border>
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Current Status" />
+                    <Picker
+                        ItemDisplayBinding="{Binding Name, x:DataType=viewmodels:OrderStatus}"
+                        ItemsSource="{Binding OrderStatuses}"
+                        SelectedItem="{Binding CurrentStatus}" />
+                </VerticalStackLayout>
+            </Border>
+
+            <Border>
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Using a key selector to set translation key based on value" />
+                    <Label Text="{mocale:LocalizeBinding CurrentStatus, KeyConverter={StaticResource KeySelectorConverter}}" />
+                </VerticalStackLayout>
+            </Border>
+
+            <Border>
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Using a post translation converter to alter the translation" />
+                    <Label Text="{mocale:LocalizeBinding CurrentStatus, KeyConverter={StaticResource KeySelectorConverter}, Converter={StaticResource PostTranslationConverter}}" />
+                </VerticalStackLayout>
+            </Border>
+
+        </VerticalStackLayout>
+
+    </ScrollView>
+</pages:BasePage>

--- a/samples/Mocale.Samples/Pages/ConverterPage.xaml.cs
+++ b/samples/Mocale.Samples/Pages/ConverterPage.xaml.cs
@@ -1,0 +1,69 @@
+using System.Globalization;
+using System.Text;
+using Mocale.Samples.ViewModels;
+using Mocale.Translations;
+
+namespace Mocale.Samples.Pages;
+
+public partial class ConverterPage : BasePage<ConverterViewModel>
+{
+    public ConverterPage(ConverterViewModel viewModel)
+        : base(viewModel)
+    {
+        InitializeComponent();
+    }
+}
+
+public class SpongebobCaseConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is null || value is not string strValue)
+        {
+            return value;
+        }
+
+        var result = new StringBuilder();
+        var toUpper = true;
+
+        foreach (var c in strValue)
+        {
+            if (char.IsLetter(c))
+            {
+                result.Append(toUpper ? char.ToUpper(c, culture) : char.ToLower(c, culture));
+                toUpper = !toUpper;
+            }
+            else
+            {
+                result.Append(c);
+            }
+        }
+
+        return result.ToString();
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+public class OrderStatusKeySelector : IKeyConverter
+{
+    public string? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is null || value is not OrderStatus orderStatus)
+        {
+            return null;
+        }
+
+        return orderStatus.Name switch
+        {
+            "Pending" => TranslationKeys.OrderStatusPending,
+            "Shipped" => TranslationKeys.OrderStatusShipped,
+            "Delivered" => TranslationKeys.OrderStatusDelivered,
+            "Cancelled" => TranslationKeys.OrderStatusCancelled,
+            _ => "Unknown order status."
+        };
+    }
+}

--- a/samples/Mocale.Samples/Resources/Locales/en-GB.json
+++ b/samples/Mocale.Samples/Resources/Locales/en-GB.json
@@ -29,5 +29,10 @@
   "ParameterPage_MultipleFormatsSameValue_Label": "A string format with the same value multiple times",
   "ParameterPage_MultipleFormatsSameValue": "Hello {0}, Hello {0}, Hello {0}",
   "CodePage_Title": "Code",
-  "CodePage_Heading": "This page is built entirely through code behind, you can see examples of everything Mocale has to offer when not using xaml!"
+  "CodePage_Heading": "This page is built entirely through code behind, you can see examples of everything Mocale has to offer when not using xaml!",
+  "ConverterPage_Title": "Converters",
+  "OrderStatus_Pending": "Order Pending",
+  "OrderStatus_Shipped": "Your Order Has Been Shipped!",
+  "OrderStatus_Delivered": "Your Order Has Been Delivered",
+  "OrderStatus_Cancelled": "Your Order Was Cancelled"
 }

--- a/samples/Mocale.Samples/Resources/Locales/fr-FR.json
+++ b/samples/Mocale.Samples/Resources/Locales/fr-FR.json
@@ -29,5 +29,11 @@
   "ParameterPage_MultipleFormatsSameValue_Label": "Un format de chaîne avec la même valeur plusieurs fois",
   "ParameterPage_MultipleFormatsSameValue": "Bonjour {0}, Bonjour {0}, Bonjour {0}",
   "CodePage_Title": "Code",
-  "CodePage_Heading": "Cette page est entièrement construite grâce au code derrière, vous pouvez voir des exemples de tout ce que Mocale a à offrir lorsque vous n'utilisez pas xaml!"
+  "CodePage_Heading": "Cette page est entièrement construite grâce au code derrière, vous pouvez voir des exemples de tout ce que Mocale a à offrir lorsque vous n'utilisez pas xaml!",
+  "ConverterPage_Title": "Convertisseurs",
+  "OrderStatus_Pending": "Commande en attente",
+  "OrderStatus_Shipped": "Votre commande a été expédiée !",
+  "OrderStatus_Delivered": "Votre commande a été livrée",
+  "OrderStatus_Cancelled": "Votre commande a été annulée"
+
 }

--- a/samples/Mocale.Samples/ViewModels/ConverterViewModel.cs
+++ b/samples/Mocale.Samples/ViewModels/ConverterViewModel.cs
@@ -1,0 +1,29 @@
+namespace Mocale.Samples.ViewModels;
+
+public partial class ConverterViewModel : BaseViewModel
+{
+    [ObservableProperty]
+    public partial OrderStatus CurrentStatus { get; set; }
+
+    public ObservableRangeCollection<OrderStatus> OrderStatuses { get; } =
+    [
+        new OrderStatus("Pending", 0),
+        new OrderStatus("Shipped", 1),
+        new OrderStatus("Delivered", 2),
+        new OrderStatus("Cancelled", 3),
+    ];
+
+    public ConverterViewModel()
+    {
+        CurrentStatus = OrderStatuses[0];
+    }
+}
+
+public partial class OrderStatus(string name, int stage) : ObservableObject
+{
+    [ObservableProperty]
+    public partial string Name { get; set; } = name;
+
+    [ObservableProperty]
+    public partial int Stage { get; set; } = stage;
+}

--- a/src/Mocale.Testing/MocaleLocatorHelper.cs
+++ b/src/Mocale.Testing/MocaleLocatorHelper.cs
@@ -1,0 +1,27 @@
+using Mocale.Abstractions;
+
+namespace Mocale.Testing;
+
+/// <summary>
+/// Mocale Locator Test Helper For Setting Internal Classes For Testing Purposes
+/// </summary>
+public static class MocaleLocatorHelper
+{
+    /// <summary>
+    /// Set Translator Manager instance during testing
+    /// </summary>
+    /// <param name="manager"></param>
+    public static void SetTranslatorManager(ITranslatorManager manager)
+    {
+        MocaleLocator.TranslatorManager = manager;
+    }
+
+    /// <summary>
+    /// Set Mocale Configuration instance during testing, this is required when localizing enums
+    /// </summary>
+    /// <param name="configuration"></param>
+    public static void SetMocaleConfiguration(IMocaleConfiguration configuration)
+    {
+        MocaleLocator.MocaleConfiguration = configuration;
+    }
+}

--- a/src/Mocale/Abstractions/IKeyConverter.cs
+++ b/src/Mocale/Abstractions/IKeyConverter.cs
@@ -1,0 +1,19 @@
+using System.Globalization;
+
+namespace Mocale.Abstractions;
+
+/// <summary>
+/// Translation Key Converter
+/// </summary>
+public interface IKeyConverter
+{
+    /// <summary>
+    /// Convert the current object into a translation key
+    /// </summary>
+    /// <param name="value">The value to convert into a translation key</param>
+    /// <param name="targetType">The target type for the control the localization is being applied</param>
+    /// <param name="parameter">The parameter to use for the conversion</param>
+    /// <param name="culture">The culture for the conversion</param>
+    /// <returns></returns>
+    string? Convert(object? value, Type targetType, object? parameter, CultureInfo culture);
+}

--- a/src/Mocale/Extensions/BindableObjectExtension.cs
+++ b/src/Mocale/Extensions/BindableObjectExtension.cs
@@ -59,6 +59,39 @@ public static class BindableObjectExtension
     }
 
     /// <summary>
+    ///
+    /// </summary>
+    /// <param name="bindableObject"></param>
+    /// <param name="property"></param>
+    /// <param name="source"></param>
+    /// <param name="keyConverter"></param>
+    /// <param name="keyConverterParameter"></param>
+    /// <param name="converter"></param>
+    /// <param name="converterParameter"></param>
+    /// <param name="stringFormat"></param>
+    public static void SetTranslationBinding(this BindableObject bindableObject, BindableProperty property, Binding source, IKeyConverter keyConverter, object? keyConverterParameter = null, IValueConverter? converter = null, object? converterParameter = null, string stringFormat = "{0}")
+    {
+        ArgumentNullException.ThrowIfNull(bindableObject, nameof(bindableObject));
+        ArgumentNullException.ThrowIfNull(source, nameof(source));
+
+        var extension = new LocalizeBindingExtension
+        {
+            KeyConverter = keyConverter,
+            KeyConverterParameter = keyConverterParameter,
+            Path = source.Path,
+            Source = source.Source,
+            Mode = source.Mode,
+            StringFormat = stringFormat,
+            Converter = converter,
+            ConverterParameter = converterParameter,
+        };
+
+        var binding = extension.ProvideValue(EmptyServiceProvider.Instance);
+
+        bindableObject.SetBinding(property, binding);
+    }
+
+    /// <summary>
     /// Set Enum Translation
     /// </summary>
     /// <param name="bindableObject">The bindable object to apply a translation</param>
@@ -171,6 +204,26 @@ public static class BindableObjectExtension
         where TView : View
     {
         SetTranslationBinding(view as BindableObject, property, source, translationKey);
+        return view;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="view"></param>
+    /// <param name="property"></param>
+    /// <param name="source"></param>
+    /// <param name="keyConverter"></param>
+    /// <param name="keyConverterParameter"></param>
+    /// <param name="converter"></param>
+    /// <param name="converterParameter"></param>
+    /// <param name="stringFormat"></param>
+    /// <typeparam name="TView"></typeparam>
+    /// <returns></returns>
+    public static TView SetTranslationBinding<TView>(this TView view, BindableProperty property, Binding source, IKeyConverter keyConverter, object? keyConverterParameter = null, IValueConverter? converter = null, object? converterParameter = null, string stringFormat = "{0}")
+        where TView : View
+    {
+        SetTranslationBinding(view as BindableObject, property, source, keyConverter, keyConverterParameter, converter, converterParameter, stringFormat);
         return view;
     }
 

--- a/src/Mocale/MocaleLocator.cs
+++ b/src/Mocale/MocaleLocator.cs
@@ -30,16 +30,6 @@ public static class MocaleLocator
     public static ITranslatorManager TranslatorManager { get; internal set; }
 
     internal static IMocaleConfiguration MocaleConfiguration { get; set; }
-
-    /// <summary>
-    /// Set custom instance of <see cref="ITranslatorManager" /> for test scenarios
-    /// </summary>
-    /// <param name="instance"></param>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public static void SetInstance(ITranslatorManager instance)
-    {
-        TranslatorManager = instance;
-    }
 }
 
 #nullable enable

--- a/tests/Mocale.UnitTests/Collections/CollectionDefinitions.cs
+++ b/tests/Mocale.UnitTests/Collections/CollectionDefinitions.cs
@@ -5,3 +5,6 @@ public class MocaleLocatorTestsCollectionDefinition;
 
 [CollectionDefinition(CollectionNames.ThreadCultureTests, DisableParallelization = true)]
 public class ThreadCultureTestsCollectionDefinition;
+
+[CollectionDefinition(CollectionNames.TestingTests, DisableParallelization = true)]
+public class TestingTestsCollectionDefinition;

--- a/tests/Mocale.UnitTests/Collections/CollectionNames.cs
+++ b/tests/Mocale.UnitTests/Collections/CollectionNames.cs
@@ -5,4 +5,6 @@ public static class CollectionNames
     public const string MocaleLocatorTests = "MocaleLocatorCollection";
 
     public const string ThreadCultureTests = "ThreadCultureCollection";
+
+    public const string TestingTests = "TestingCollection";
 }

--- a/tests/Mocale.UnitTests/Extensions/BindableObjectExtensionTests.cs
+++ b/tests/Mocale.UnitTests/Extensions/BindableObjectExtensionTests.cs
@@ -19,7 +19,7 @@ public partial class BindableObjectExtensionTests : ControlsFixtureBase
 
     public BindableObjectExtensionTests()
     {
-        MocaleLocator.SetInstance(translatorManager);
+        MocaleLocatorHelper.SetTranslatorManager(translatorManager);
     }
 
     #endregion Setup

--- a/tests/Mocale.UnitTests/Extensions/LocalizeBindingExtensionTests.cs
+++ b/tests/Mocale.UnitTests/Extensions/LocalizeBindingExtensionTests.cs
@@ -8,13 +8,11 @@ using Mocale.Extensions;
 using Mocale.Models;
 using Mocale.Testing;
 using Mocale.UnitTests.Collections;
-using Mocale.UnitTests.Fixtures;
-using Xunit.Sdk;
 
 namespace Mocale.UnitTests.Extensions;
 
 [Collection(CollectionNames.MocaleLocatorTests)]
-public partial class LocalizeMultiBindingExtensionTests : FixtureBase<LocalizeBindingExtension>
+public partial class LocalizeBindingExtensionTests : FixtureBase<LocalizeBindingExtension>
 {
     #region Setup
 

--- a/tests/Mocale.UnitTests/Extensions/LocalizeBindingExtensionTests.cs
+++ b/tests/Mocale.UnitTests/Extensions/LocalizeBindingExtensionTests.cs
@@ -1,4 +1,6 @@
+using System.Collections.ObjectModel;
 using System.Globalization;
+using System.Text;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Mocale.Abstractions;
 using Mocale.Enums;
@@ -44,15 +46,17 @@ public partial class LocalizeMultiBindingExtensionTests : FixtureBase<LocalizeBi
     }
 
     [Fact]
-    public void ProvideValue_WhenKeyIsNull_ShouldThrow()
+    public void ProvideValue_WhenKeyAndKeyConverterAreNull_ShouldThrow()
     {
         // Arrange
+        Sut.TranslationKey = null;
+        Sut.KeyConverter = null;
 
         // Act
-        var ex = Assert.Throws<ArgumentNullException>(() => Sut.ProvideValue(serviceProvider));
+        var ex = Assert.Throws<InvalidOperationException>(() => Sut.ProvideValue(serviceProvider));
 
         // Assert
-        Assert.Equal("Value cannot be null. (Parameter 'TranslationKey')", ex.Message);
+        Assert.Equal("Neither TranslationKey or KeyConverter were set. Use must set one of these, please see the documentation for details", ex.Message);
     }
 
     [Fact]
@@ -84,7 +88,7 @@ public partial class LocalizeMultiBindingExtensionTests : FixtureBase<LocalizeBi
     }
 
     [Fact]
-    public void ProvideValue_WhenValuesAreSet_ShouldPassValuesToSecondBinding()
+    public void ProvideValue_WhenTranslationKeyIsSetAndValuesAreSet_ShouldPassValuesToSecondBinding()
     {
         // Arrange
         var converter = Mock.Of<IValueConverter>();
@@ -121,7 +125,7 @@ public partial class LocalizeMultiBindingExtensionTests : FixtureBase<LocalizeBi
     }
 
     [Fact]
-    public void ProvideValue_ShouldBehaveTheSame_WhenUsingIMarkupExtension()
+    public void ProvideValue_WhenTranslationKeyIsSetShouldBehaveTheSame_WhenUsingIMarkupExtension()
     {
         // Arrange
         var converter = Mock.Of<IValueConverter>();
@@ -159,8 +163,11 @@ public partial class LocalizeMultiBindingExtensionTests : FixtureBase<LocalizeBi
     }
 
     [Fact]
-    public void Convert_WhenThereArentTwoInputs_ShouldReturnEmptyString()
+    public void ConvertTranslationKey_WhenThereArentTwoInputs_ShouldReturnEmptyString()
     {
+        Sut.TranslationKey = "Key";
+        Sut.KeyConverter = null;
+
         var noArgs = Sut.Convert([], typeof(Label), null!, CultureInfo.InvariantCulture);
         var oneArg = Sut.Convert(["en-GB"], typeof(Label), null!, CultureInfo.InvariantCulture);
         var argsThrice = Sut.Convert(["sausage roll", "sausage roll", "sausage roll"], typeof(Label), null!, CultureInfo.InvariantCulture);
@@ -171,16 +178,22 @@ public partial class LocalizeMultiBindingExtensionTests : FixtureBase<LocalizeBi
     }
 
     [Fact]
-    public void Convert_WhenFirstValueIsNotString_ShouldReturnEmpty()
+    public void ConvertTranslationKey_WhenFirstValueIsNotString_ShouldReturnEmpty()
     {
+        Sut.TranslationKey = "Key";
+        Sut.KeyConverter = null;
+
         var invalidInput = Sut.Convert([1234, "Name"], typeof(Label), null!, CultureInfo.InvariantCulture);
 
         Assert.Equal(string.Empty, invalidInput);
     }
 
     [Fact]
-    public void Convert_WhenTranslationIsNotFormatString_ShouldNotPlaceBindedValueInString()
+    public void ConvertTranslationKey_WhenTranslationIsNotFormatString_ShouldNotPlaceBindedValueInString()
     {
+        Sut.TranslationKey = "Key";
+        Sut.KeyConverter = null;
+
         // This test is to show that parameterization won't work when not working with parameterized strings!
         var formattedString = Sut.Convert(["I am not a format string", "Format me in your string!"], typeof(Label), null!, CultureInfo.InvariantCulture);
 
@@ -188,16 +201,22 @@ public partial class LocalizeMultiBindingExtensionTests : FixtureBase<LocalizeBi
     }
 
     [Fact]
-    public void Convert_WhenSecondValueIsString_ShouldFormatCorrectly()
+    public void ConvertTranslationKey_WhenSecondValueIsString_ShouldFormatCorrectly()
     {
+        Sut.TranslationKey = "Key";
+        Sut.KeyConverter = null;
+
         var result = Sut.Convert(["Hello {0}", "Name"], typeof(Label), null!, CultureInfo.InvariantCulture);
 
         Assert.Equal("Hello Name", result);
     }
 
     [Fact]
-    public void Convert_WhenSecondValueIsNull_ShouldNotThrow()
+    public void ConvertTranslationKey_WhenSecondValueIsNull_ShouldNotThrow()
     {
+        Sut.TranslationKey = "Key";
+        Sut.KeyConverter = null;
+
         // When bindings first attach they will fire a pass null, inspite of what #nullable has to say about it!!!
         var result = Sut.Convert(["Hello '{0}'", null!], typeof(Label), null!, CultureInfo.InvariantCulture);
 
@@ -206,8 +225,11 @@ public partial class LocalizeMultiBindingExtensionTests : FixtureBase<LocalizeBi
 
     [Theory]
     [MemberData(nameof(SecondValueNotStringTestData))]
-    public void Convert_WhenSecondValueIsNotString_ShouldFormatCorrectly(string formatString, object value, string expectedValue, CultureInfo cultureInfo)
+    public void ConvertTranslationKey_WhenSecondValueIsNotString_ShouldFormatCorrectly(string formatString, object value, string expectedValue, CultureInfo cultureInfo)
     {
+        Sut.TranslationKey = "Key";
+        Sut.KeyConverter = null;
+
         var result = Sut.Convert([formatString, value], typeof(Label), null!, cultureInfo);
 
         Assert.Equal(expectedValue, result);
@@ -220,7 +242,7 @@ public partial class LocalizeMultiBindingExtensionTests : FixtureBase<LocalizeBi
     }
 
     [Fact]
-    public void IntegrationTest()
+    public void IntegrationTest_ForTranslationKey()
     {
         _ = new ControlsFixtureBase();
         var label = new Label();
@@ -268,6 +290,341 @@ public partial class LocalizeMultiBindingExtensionTests : FixtureBase<LocalizeBi
         Assert.Equal("Bonjour Alex", label.Text);
     }
 
+    [Fact]
+    public void ProvideValue_WhenKeyConverterIsSet_ShouldCreateBinding()
+    {
+        // Arrange
+        Sut.TranslationKey = null;
+        Sut.KeyConverter = new ChilliKeyConverter();
+
+        // Act
+        var multiBinding = Sut.ProvideValue(serviceProvider);
+
+        // Assert
+        Assert.Equal("{0}", multiBinding.StringFormat);
+        Assert.Equal(Sut, multiBinding.Converter);
+        Assert.Equal(BindingMode.OneWay, multiBinding.Mode);
+        Assert.Equal(2, multiBinding.Bindings.Count);
+
+        var bindingOne = Assert.IsType<Binding>(multiBinding.Bindings[0]);
+        Assert.Equal("CurrentCulture", bindingOne.Path);
+        Assert.Equal(BindingMode.OneWay, bindingOne.Mode);
+        Assert.Equal(translatorManager, bindingOne.Source);
+
+        var bindingTwo = Assert.IsType<Binding>(multiBinding.Bindings[1]);
+        Assert.Equal(".", bindingTwo.Path);
+        Assert.Equal(BindingMode.OneWay, bindingTwo.Mode);
+        Assert.Null(bindingTwo.Converter);
+        Assert.Null(bindingTwo.ConverterParameter);
+        Assert.Null(bindingTwo.Source);
+    }
+
+    [Fact]
+    public void ProvideValue_WhenKeyConverterIsSetShouldBehaveTheSame_WhenUsingIMarkupExtension()
+    {
+        // Arrange
+        var converter = Mock.Of<IValueConverter>();
+        var source = new Picker();
+
+        Sut.TranslationKey = null;
+        Sut.KeyConverter = new ChilliKeyConverter();
+        Sut.Path = "Name";
+        Sut.Mode = BindingMode.TwoWay;
+        Sut.StringFormat = "!!{0}__";
+        Sut.Converter = converter;
+        Sut.ConverterParameter = 1357;
+        Sut.Source = source;
+
+        // Act
+        var value = ((IMarkupExtension)Sut).ProvideValue(serviceProvider);
+
+        // Assert
+        var multiBinding = Assert.IsType<MultiBinding>(value);
+        Assert.Equal("!!{0}__", multiBinding.StringFormat);
+        Assert.Equal(Sut, multiBinding.Converter);
+        Assert.Equal(BindingMode.OneWay, multiBinding.Mode);
+        Assert.Equal(2, multiBinding.Bindings.Count);
+
+        var bindingOne = Assert.IsType<Binding>(multiBinding.Bindings[0]);
+        Assert.Equal("CurrentCulture", bindingOne.Path);
+        Assert.Equal(BindingMode.OneWay, bindingOne.Mode);
+        Assert.Equal(translatorManager, bindingOne.Source);
+
+        var bindingTwo = Assert.IsType<Binding>(multiBinding.Bindings[1]);
+        Assert.Equal("Name", bindingTwo.Path);
+        Assert.Equal(BindingMode.TwoWay, bindingTwo.Mode);
+        Assert.Null(bindingTwo.Converter);
+        Assert.Null(bindingTwo.ConverterParameter);
+        Assert.Equal(source, bindingTwo.Source);
+    }
+
+    [Fact]
+    public void ConvertKeyConverter_WhenKeyConverterIsNull_ShouldThgrow()
+    {
+        // Arrange
+        Sut.TranslationKey = null;
+        Sut.KeyConverter = null;
+
+        // Act
+        var ex = Assert.Throws<InvalidOperationException>(() => Sut.ConvertKeyConverterBinding(
+            [
+                "en-GB",
+                new ChilliInfo()
+                {
+                    Name = "Bell Pepper", Origin = "The Americas", Scovilles = new ScovilleHeatUnits(0, 0)
+                }
+            ],
+            typeof(Label), new CultureInfo("en-GB")));
+
+        Assert.Equal("Key converter was null, unable to convert binding.", ex.Message);
+    }
+
+    [Fact]
+    public void ConvertKeyConverter_WhenThereArentTwoInputs_ShouldReturnEmptyString()
+    {
+        Sut.TranslationKey = null;
+        Sut.KeyConverter = new ChilliKeyConverter();
+
+        var noArgs = Sut.Convert([], typeof(Label), null!, CultureInfo.InvariantCulture);
+        var oneArg = Sut.Convert(["en-GB"], typeof(Label), null!, CultureInfo.InvariantCulture);
+        var argsThrice = Sut.Convert(["sausage roll", "sausage roll", "sausage roll"], typeof(Label), null!, CultureInfo.InvariantCulture);
+
+        Assert.Equal(string.Empty, noArgs);
+        Assert.Equal(string.Empty, oneArg);
+        Assert.Equal(string.Empty, argsThrice);
+    }
+
+    [Fact]
+    public void ConvertKeyConverter_WhenKeyConverterDoesntReturnPopulatedString_ShouldReturnEmptyString()
+    {
+        // Arrange
+        Sut.TranslationKey = null;
+        Sut.KeyConverter = new EmptyKeyConverter();
+
+        var bellPepper = new ChilliInfo()
+        {
+            Name = "Bell Pepper",
+            Origin = "The Americas",
+            Scovilles = new ScovilleHeatUnits(0, 0)
+        };
+
+        // Act
+        var result = Sut.Convert(["en-GB", bellPepper], typeof(Label), null!, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void ConvertKeyConverter_WhenKeyConverterProvidesKeyAndConverterIsNull_ShouldTranslateAndReturn()
+    {
+        // Arrange
+        Sut.TranslationKey = null;
+        Sut.KeyConverter = new ChilliKeyConverter();
+
+        translatorManager.UpdateTranslations(new Localization(new CultureInfo("en-GB"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "BellPepperKey", "Bell Pepper" },
+                { "JalapenoKey", "Jalapeno" },
+                { "BirdsEyeKey", "Bird's Eye" },
+                { "HabaneroKey", "Habanero" },
+                { "CarolinaReaperKey", "Carolina Reaper" }
+            }
+        }, TranslationSource.Internal);
+
+        var bellPepper = new ChilliInfo()
+        {
+            Name = "Bell Pepper",
+            Origin = "The Americas",
+            Scovilles = new ScovilleHeatUnits(0, 0)
+        };
+
+        // Act
+        var result = Sut.Convert(["en-GB", bellPepper], typeof(Label), null!, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.Equal("Bell Pepper", result);
+    }
+
+    [Fact]
+    public void ConvertKeyConverter_WhenKeyConverterProvidesKeyWithKeyParameter_ShouldTranslateAndReturn()
+    {
+        // Arrange
+        Sut.TranslationKey = null;
+        Sut.KeyConverter = new ChilliKeyConverter();
+        Sut.KeyConverterParameter = true;
+
+        translatorManager.UpdateTranslations(new Localization(new CultureInfo("en-GB"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "BellPepperKey", "Bell Pepper" },
+                { "JalapenoKey", "Jalapeno" },
+                { "BirdsEyeKey", "Bird's Eye" },
+                { "HabaneroKey", "Habanero" },
+                { "CarolinaReaperKey", "Carolina Reaper" },
+                { "BellPepperEmojiKey", "Bell Pepper 🫑" },
+                { "JalapenoEmojiKey", "Jalapeno 🌶️" },
+                { "BirdsEyeEmojiKey", "Bird's Eye 🕊️👁️" },
+                { "HabaneroEmojiKey", "Habanero 🔥" },
+                { "CarolinaReaperEmojiKey", "Carolina Reaper 🔥☠️" }
+            }
+        }, TranslationSource.Internal);
+
+        var bellPepper = new ChilliInfo()
+        {
+            Name = "Bell Pepper",
+            Origin = "The Americas",
+            Scovilles = new ScovilleHeatUnits(0, 0)
+        };
+
+        // Act
+        var result = Sut.Convert(["en-GB", bellPepper], typeof(Label), null!, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.Equal("Bell Pepper 🫑", result);
+    }
+
+    [Fact]
+    public void ConvertKeyConverter_WhenKeyConverterProvidesKeyAndConverterIsSet_ShouldTranslateApplyConverter()
+    {
+        // Arrange
+        Sut.TranslationKey = null;
+        Sut.KeyConverter = new ChilliKeyConverter();
+        Sut.Converter = new UpperCaseRepeatConverter();
+
+        translatorManager.UpdateTranslations(new Localization(new CultureInfo("en-GB"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "BellPepperKey", "Bell Pepper" },
+                { "JalapenoKey", "Jalapeno" },
+                { "BirdsEyeKey", "Bird's Eye" },
+                { "HabaneroKey", "Habanero" },
+                { "CarolinaReaperKey", "Carolina Reaper" }
+            }
+        }, TranslationSource.Internal);
+
+        var bellPepper = new ChilliInfo()
+        {
+            Name = "Bell Pepper",
+            Origin = "The Americas",
+            Scovilles = new ScovilleHeatUnits(0, 0)
+        };
+
+        // Act
+        var result = Sut.Convert(["en-GB", bellPepper], typeof(Label), null!, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.Equal("BELL PEPPER", result);
+    }
+
+    [Fact]
+    public void ConvertKeyConverter_WhenKeyConverterProvidesKeyAndConverterIsSetWithParameter_ShouldTranslateApplyConverter()
+    {
+        // Arrange
+        Sut.TranslationKey = null;
+        Sut.KeyConverter = new ChilliKeyConverter();
+        Sut.Converter = new UpperCaseRepeatConverter();
+        Sut.ConverterParameter = 3;
+
+        translatorManager.UpdateTranslations(new Localization(new CultureInfo("en-GB"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "BellPepperKey", "Bell Pepper" },
+                { "JalapenoKey", "Jalapeno" },
+                { "BirdsEyeKey", "Bird's Eye" },
+                { "HabaneroKey", "Habanero" },
+                { "CarolinaReaperKey", "Carolina Reaper" }
+            }
+        }, TranslationSource.Internal);
+
+        var bellPepper = new ChilliInfo()
+        {
+            Name = "Bell Pepper",
+            Origin = "The Americas",
+            Scovilles = new ScovilleHeatUnits(0, 0)
+        };
+
+        // Act
+        var result = Sut.Convert(["en-GB", bellPepper], typeof(Label), null!, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.Equal("BELL PEPPERBELL PEPPERBELL PEPPER", result);
+    }
+
+    [Fact]
+    public void IntegrationTest_ForKeyConverter()
+    {
+        _ = new ControlsFixtureBase();
+        var label = new Label();
+
+        var viewModel = new ChilliViewModel();
+
+        Sut.TranslationKey = null;
+        Sut.KeyConverter = new ChilliKeyConverter();
+        Sut.KeyConverterParameter = true;
+        Sut.Path = nameof(ChilliViewModel.SelectedChilli);
+        Sut.Source = viewModel;
+
+        label.SetBinding(Label.TextProperty, Sut.ProvideValue(Mock.Of<IServiceProvider>()));
+
+        Assert.Equal("", label.Text);
+
+        var enGbLocalization = new Localization(new CultureInfo("en-GB"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "BellPepperKey", "Bell Pepper" },
+                { "JalapenoKey", "Jalapeno" },
+                { "BirdsEyeKey", "Bird's Eye" },
+                { "HabaneroKey", "Habanero" },
+                { "CarolinaReaperKey", "Carolina Reaper" },
+                { "BellPepperEmojiKey", "Bell Pepper 🫑" },
+                { "JalapenoEmojiKey", "Jalapeno 🌶️" },
+                { "BirdsEyeEmojiKey", "Bird's Eye 🕊️👁️" },
+                { "HabaneroEmojiKey", "Habanero 🔥" },
+                { "CarolinaReaperEmojiKey", "Carolina Reaper 🔥☠️" }
+            }
+        };
+
+        translatorManager.UpdateTranslations(enGbLocalization, TranslationSource.Internal);
+
+        Assert.Equal("", label.Text);
+
+        viewModel.SelectedChilli = viewModel.Chillis[2];
+
+        Assert.Equal("Bird's Eye 🕊️👁️", label.Text);
+
+        var frFRLocalization = new Localization(new CultureInfo("fr-FR"))
+        {
+            Translations = new Dictionary<string, string>()
+            {
+                { "BellPepperKey", "Poivron" },
+                { "JalapenoKey", "Jalapeño" },
+                { "BirdsEyeKey", "Piment oiseau" },
+                { "HabaneroKey", "Habanero" },
+                { "CarolinaReaperKey", "Carolina Reaper" },
+                { "BellPepperEmojiKey", "Poivron 🫑" },
+                { "JalapenoEmojiKey", "Jalapeño 🌶️" },
+                { "BirdsEyeEmojiKey", "Piment oiseau 🕊️👁️" },
+                { "HabaneroEmojiKey", "Habanero 🔥" },
+                { "CarolinaReaperEmojiKey", "Carolina Reaper 🔥☠️" }
+            }
+        };
+
+        translatorManager.UpdateTranslations(frFRLocalization, TranslationSource.Internal);
+
+        Assert.Equal("Piment oiseau 🕊️👁️", label.Text);
+
+        viewModel.SelectedChilli = viewModel.Chillis[3];
+
+        Assert.Equal("Habanero 🔥", label.Text);
+    }
+
     #endregion Tests
 
     #region Test Data
@@ -282,6 +639,134 @@ public partial class LocalizeMultiBindingExtensionTests : FixtureBase<LocalizeBi
     {
         [ObservableProperty]
         public partial string Name { get; set; } = string.Empty;
+    }
+
+    private record ScovilleHeatUnits(int LowerBound, int UpperBound);
+
+    private partial class ChilliInfo : ObservableObject
+    {
+        [ObservableProperty]
+        public partial string Name { get; set; } = string.Empty;
+
+        [ObservableProperty]
+        public partial string Origin { get; set; } = string.Empty;
+
+        [ObservableProperty]
+        public required partial ScovilleHeatUnits Scovilles { get; set; }
+    }
+
+    private sealed partial class ChilliViewModel : ObservableObject
+    {
+        public ObservableCollection<ChilliInfo> Chillis { get; } =
+        [
+            new ChilliInfo()
+            {
+                Name = "Bell Pepper",
+                Origin = "The Americas",
+                Scovilles = new ScovilleHeatUnits(0, 0)
+            },
+            new ChilliInfo()
+            {
+                Name = "Jalapeno pepper",
+                Origin = "Native To Mexico",
+                Scovilles = new ScovilleHeatUnits(2500, 10_000)
+            },
+            new ChilliInfo()
+            {
+                Name = "Bird's Eye Chilli",
+                Origin = "Native To Mexico",
+                Scovilles = new ScovilleHeatUnits(50_000, 100_000)
+            },
+            new ChilliInfo()
+            {
+                Name = "Habanero Chilli",
+                Origin = "The Amazon",
+                Scovilles = new ScovilleHeatUnits(100_000, 350_000)
+            },
+            new ChilliInfo()
+            {
+                Name = "Carolina Reaper",
+                Origin = "Fort Mill, South Carolina, USA",
+                Scovilles = new ScovilleHeatUnits(1_500_000, 2_500_000)
+            }
+        ];
+
+        [ObservableProperty]
+        public partial ChilliInfo? SelectedChilli { get; set; }
+    }
+
+    private sealed class ChilliKeyConverter : IKeyConverter
+    {
+        public string? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is not ChilliInfo chilliInfo)
+            {
+                return null;
+            }
+
+            if (parameter is not bool useEmoji)
+            {
+                return chilliInfo.Name switch
+                {
+                    "Bell Pepper" => "BellPepperKey",
+                    "Jalapeno pepper" => "JalapenoKey",
+                    "Bird's Eye Chilli" => "BirdsEyeKey",
+                    "Habanero Chilli" => "HabaneroKey",
+                    "Carolina Reaper" => "CarolinaReaperKey",
+                    _ => null
+                };
+            }
+
+            return chilliInfo.Name switch
+            {
+                "Bell Pepper" => useEmoji ? "BellPepperEmojiKey" : "BellPepperKey",
+                "Jalapeno pepper" => useEmoji ? "JalapenoEmojiKey" : "JalapenoKey",
+                "Bird's Eye Chilli" => useEmoji ? "BirdsEyeEmojiKey" : "BirdsEyeKey",
+                "Habanero Chilli" => useEmoji ? "HabaneroEmojiKey" : "HabaneroKey",
+                "Carolina Reaper" => useEmoji ? "CarolinaReaperEmojiKey" : "CarolinaReaperKey",
+                _ => null
+            };
+        }
+    }
+
+    private class EmptyKeyConverter : IKeyConverter
+    {
+        public string? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            return null;
+        }
+    }
+
+    private class UpperCaseRepeatConverter : IValueConverter
+    {
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is string str)
+            {
+                var upperCase = str.ToUpperInvariant();
+
+                if (parameter is int repeats)
+                {
+                    var sb = new StringBuilder();
+                    for (var i = 0; i < repeats; i++)
+                    {
+                        sb.Append(upperCase);
+                    }
+                    return sb.ToString();
+                }
+                else
+                {
+                    return upperCase;
+                }
+            }
+
+            return value;
+        }
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     #endregion Test Data

--- a/tests/Mocale.UnitTests/Extensions/LocalizeBindingExtensionTests.cs
+++ b/tests/Mocale.UnitTests/Extensions/LocalizeBindingExtensionTests.cs
@@ -35,7 +35,7 @@ public partial class LocalizeMultiBindingExtensionTests : FixtureBase<LocalizeBi
     {
         // Arrange
         var translatorManagerMock = new Mock<ITranslatorManager>();
-        MocaleLocator.SetInstance(translatorManagerMock.Object);
+        MocaleLocatorHelper.SetTranslatorManager(translatorManagerMock.Object);
 
         // Act
         var localizeExtension = new LocalizeBindingExtension();

--- a/tests/Mocale.UnitTests/Extensions/LocalizeEnumExtensionTests.cs
+++ b/tests/Mocale.UnitTests/Extensions/LocalizeEnumExtensionTests.cs
@@ -36,8 +36,8 @@ public partial class LocalizeEnumExtensionTests : FixtureBase<LocalizeEnumExtens
         var translatorManagerMock = new Mock<ITranslatorManager>();
         var configurationMock = new Mock<IMocaleConfiguration>();
 
-        MocaleLocator.SetInstance(translatorManagerMock.Object);
-        MocaleLocator.MocaleConfiguration = configurationMock.Object;
+        MocaleLocatorHelper.SetTranslatorManager(translatorManagerMock.Object);
+        MocaleLocatorHelper.SetMocaleConfiguration(configurationMock.Object);
 
         // Act
         var localizeExtension = new LocalizeEnumExtension();

--- a/tests/Mocale.UnitTests/Extensions/LocalizeExtensionTests.cs
+++ b/tests/Mocale.UnitTests/Extensions/LocalizeExtensionTests.cs
@@ -31,7 +31,7 @@ public class LocalizeExtensionTests : FixtureBase<LocalizeExtension>
     {
         // Arrange
         var translatorManagerMock = new Mock<ITranslatorManager>();
-        MocaleLocator.SetInstance(translatorManagerMock.Object);
+        MocaleLocatorHelper.SetTranslatorManager(translatorManagerMock.Object);
 
         // Act
         var localizeExtension = new LocalizeExtension();

--- a/tests/Mocale.UnitTests/Extensions/LocalizeMultiBindingTests.cs
+++ b/tests/Mocale.UnitTests/Extensions/LocalizeMultiBindingTests.cs
@@ -38,7 +38,7 @@ public partial class LocalizeMultiBindingTests : FixtureBase<LocalizeMultiBindin
     {
         // Arrange
         var translatorManagerMock = new Mock<ITranslatorManager>();
-        MocaleLocator.SetInstance(translatorManagerMock.Object);
+        MocaleLocatorHelper.SetTranslatorManager(translatorManagerMock.Object);
 
         // Act
         var localizeExtension = new LocalizeMultiBindingExtension();

--- a/tests/Mocale.UnitTests/Fixtures/FixtureBase.cs
+++ b/tests/Mocale.UnitTests/Fixtures/FixtureBase.cs
@@ -1,6 +1,6 @@
-namespace Mocale.UnitTests;
+namespace Mocale.UnitTests.Fixtures;
 
-public abstract class FixtureBase<TSut>
+public abstract class FixtureBase<TSut> : MocaleLocatorFixture
 {
     private Lazy<TSut> SutLazy { get; init; }
 
@@ -14,7 +14,7 @@ public abstract class FixtureBase<TSut>
     public abstract TSut CreateSystemUnderTest();
 }
 
-public abstract class FixtureBase
+public abstract class FixtureBase : MocaleLocatorFixture
 {
     private Lazy<object> SutLazy { get; init; }
 

--- a/tests/Mocale.UnitTests/Fixtures/MocaleLocatorFixture.cs
+++ b/tests/Mocale.UnitTests/Fixtures/MocaleLocatorFixture.cs
@@ -1,0 +1,11 @@
+namespace Mocale.UnitTests.Fixtures;
+
+public class MocaleLocatorFixture : IDisposable
+{
+    public void Dispose()
+    {
+        MocaleLocator.MocaleConfiguration = null;
+        MocaleLocator.TranslatorManager = null;
+    }
+}
+

--- a/tests/Mocale.UnitTests/MocaleLocatorTests.cs
+++ b/tests/Mocale.UnitTests/MocaleLocatorTests.cs
@@ -1,4 +1,5 @@
 using Mocale.Abstractions;
+using Mocale.Testing;
 
 namespace Mocale.UnitTests;
 
@@ -11,7 +12,7 @@ public class MocaleLocatorTests
         var translatorManager = new Mock<ITranslatorManager>();
 
         // Act
-        MocaleLocator.SetInstance(translatorManager.Object);
+        MocaleLocatorHelper.SetTranslatorManager(translatorManager.Object);
 
         // Assert
         Assert.Equal(translatorManager.Object, MocaleLocator.TranslatorManager);

--- a/tests/Mocale.UnitTests/Properties/GlobalUsings.cs
+++ b/tests/Mocale.UnitTests/Properties/GlobalUsings.cs
@@ -2,3 +2,4 @@ global using Xunit;
 global using FluentAssertions;
 global using Moq;
 global using Mocale.UnitTests.TestUtils;
+global using Mocale.UnitTests.Fixtures;

--- a/tests/Mocale.UnitTests/Testing/MocaleLocatorHelperTests.cs
+++ b/tests/Mocale.UnitTests/Testing/MocaleLocatorHelperTests.cs
@@ -1,0 +1,46 @@
+using Mocale.Abstractions;
+using Mocale.Testing;
+using Mocale.UnitTests.Collections;
+using Mocale.UnitTests.Fixtures;
+
+namespace Mocale.UnitTests.Testing;
+
+[Collection(CollectionNames.TestingTests)]
+public class MocaleLocatorHelperTests : MocaleLocatorFixture
+{
+    public MocaleLocatorHelperTests()
+    {
+        MocaleLocator.MocaleConfiguration = null;
+        MocaleLocator.TranslatorManager = null;
+    }
+
+    [Fact]
+    public void SetTranslatorManager()
+    {
+        // Arrange
+        Assert.Null(MocaleLocator.TranslatorManager);
+
+        var mockTranslatorManager = Mock.Of<ITranslatorManager>();
+
+        // Act
+        MocaleLocatorHelper.SetTranslatorManager(mockTranslatorManager);
+
+        // Assert
+        Assert.Equal(mockTranslatorManager, MocaleLocator.TranslatorManager);
+    }
+
+    [Fact]
+    public void SetMocaleConfiguration()
+    {
+        // Arrange
+        Assert.Null(MocaleLocator.MocaleConfiguration);
+
+        var mockTranslatorManager = Mock.Of<IMocaleConfiguration>();
+
+        // Act
+        MocaleLocatorHelper.SetMocaleConfiguration(mockTranslatorManager);
+
+        // Assert
+        Assert.Equal(mockTranslatorManager, MocaleLocator.MocaleConfiguration);
+    }
+}


### PR DESCRIPTION
This PR adds some new functionality for localized binding. Currently Mocale assumes your binding is going to be a parameterized type affair, what if you want to set a fixed key based on the state of the binded object? this has now been added:

## New Bindings
```xml
<Label Text="{mocale:LocalizeBinding CurrentStatus, KeyConverter={StaticResource KeySelectorConverter}}" />
```

Simply create a `IKeyConverter`, almost identical behaviour to `IValueConverter`, but it returns a string. When the locale changes, or the object updates the localization will be reevaluated and updated accordingly.

The same has been added via code bindings to ensure xaml & cs parity.

## Testing Changes

**Breaking**
Removed `SetInstance` from `MocaleLocator`

Added `MocaleLocatorHelper` which is capable of setting `TranslatorManager` & `MocaleConfiguration` instances directly. This should only be used in test scenarios, but now this code is purely in the testing package I'm happier with the separation of concerns.

To set the instances in tests use:
`MocaleLocatorHelper.SetTranslatorManager(...)`
`MocaleLocatorHelper.SetMocaleConfiguration(...)`

Don't forget to have teardown logic to clear the static instances!

## Issues Addressed

- #61
- #60 